### PR TITLE
fix(game): fix exception in StructureLab.runReaction()

### DIFF
--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -434,7 +434,8 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(lab1.mineralAmount < C.LAB_REACTION_AMOUNT || lab2.mineralAmount < C.LAB_REACTION_AMOUNT) {
             return C.ERR_NOT_ENOUGH_RESOURCES;
         }
-        if(!C.REACTIONS[lab1.mineralType][lab2.mineralType] || this.mineralType && this.mineralType != C.REACTIONS[lab1.mineralType][lab2.mineralType]) {
+        if(!(lab1.mineralType in C.REACTIONS) || !C.REACTIONS[lab1.mineralType][lab2.mineralType] ||
+        this.mineralType && this.mineralType != C.REACTIONS[lab1.mineralType][lab2.mineralType]) {
             return C.ERR_INVALID_ARGS;
         }
 


### PR DESCRIPTION
Currently StructureLab.runReaction() causes the following exception if the lab passed as "lab1" contains a catalyzed tier 3 boost:

`TypeError: Cannot read property 'XLHO2' of undefined
    at .runReaction (evalmachine.<anonymous>:1:72)`

See potential fix. 