### PR TITLE
Bugfix/create creep without memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@screeps/engine",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "bin": {
     "screeps-engine-main": "dist/main.js",
     "screeps-engine-runner": "dist/runner.js",

--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -970,15 +970,12 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         createdCreepNames.push(name);
 
-        if(_.isUndefined(globals.Memory.creeps)) {
-            globals.Memory.creeps = {};
-        }
-        if(_.isObject(globals.Memory.creeps)) {
-            if(!_.isUndefined(creepMemory)) {
-                globals.Memory.creeps[name] = creepMemory;
+        if(!_.isUndefined(creepMemory)) {
+            if(_.isUndefined(globals.Memory.creeps)) {
+                globals.Memory.creeps = {};
             }
-            else {
-                globals.Memory.creeps[name] = globals.Memory.creeps[name] || {};
+            if(_.isObject(globals.Memory.creeps)) {
+                globals.Memory.creeps[name] = creepMemory;
             }
         }
 


### PR DESCRIPTION
# Description
Previously createCreep always created a memory object for the creep
being created. This meant that even when using RawMemory, the default
JSON parser would be invoked anyways when creating a creep. This is
especially a problem if the raw memory cannot be parsed into a JSON
object, resulting in an exception in createCreep.

With this commit the memory access is only done when the creepMemory
parameter is not undefined.

# Possible problems
This will not be noticable to users who already use the creepMemory parameter or access a creeps memory via the memory property on the creep, as it has some auto-initialization logic for the creep memory. But users who rely on the automatic initialization of a creep's memory and use the Memory global to access it might get errors. This needs to be taken into account in the documentation