### PR TITLE
Only check for a rampart at the same position

### DIFF
--- a/src/processor/intents/creeps/withdraw.js
+++ b/src/processor/intents/creeps/withdraw.js
@@ -23,7 +23,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
     if(!target) {
         return;
     }
-    if(object.user != target.user && _.any(roomObjects, i => i.type == C.STRUCTURE_RAMPART && i.user != object.user && !i.isPublic)) {
+    if(object.user != target.user && _.any(roomObjects, i => i.type == C.STRUCTURE_RAMPART && i.user != object.user && !i.isPublic && i.x == target.x && i.y == target.y)) {
         return;
     }
     if(Math.abs(target.x - object.x) > 1 || Math.abs(target.y - object.y) > 1) {


### PR DESCRIPTION
A recent change led to an issue where creeps could not withdraw from any object regardless of where the unowned ramparts were in the room. This should allow the creeps to withdraw from unprotected objects. This will still prevent a player from withdrawing from objects under another players rampart. 