### PR TITLE
Add Room.mineral property.

### DIFF
--- a/src/game/minerals.js
+++ b/src/game/minerals.js
@@ -27,6 +27,8 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         var _data = data(id);
         globals.RoomObject.call(this, _data.x, _data.y, _data.room);
         this.id = id;
+        
+        register.rooms[_data.room].mineral = this;
     });
 
     Mineral.prototype = Object.create(globals.RoomObject.prototype);


### PR DESCRIPTION
There can only be a single mineral per room, so it gives reason there should be a `Room#mineral` property alongside controller, storage, and terminal. Like Storage and Terminal, if there is no mineral, it will be undefined.