### PR TITLE
Use bulk.inc for renewCreep

### DIFF
--- a/src/processor/intents/spawns/renew-creep.js
+++ b/src/processor/intents/spawns/renew-creep.js
@@ -39,7 +39,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
 
     target.ageTime += effect;
     target.actionLog.healed = {x: object.x, y: object.y};
-    bulk.update(target, {ageTime: target.ageTime});
+    bulk.inc(target, 'ageTime', effect);
 
     if(_.any(target.body, i => !!i.boost)) {
         target.body.forEach(i => {


### PR DESCRIPTION
This allows multiple spawners using `renewCreep` on the same target to correctly update the lifetime of the creep.

Docs don't suggest this shouldn't be possible, and without this, creep renewal is somewhat not worth it -- with it, however, creep renewal means overall renewal time for creeps can be much shorter than creating one from scratch, if you have multiple spawners doing it.