### PR TITLE
Fix random behavior due to intents, while disallowing overheal

### DIFF
--- a/src/processor/intents/_damage.js
+++ b/src/processor/intents/_damage.js
@@ -70,12 +70,7 @@ module.exports = function(object, target, damage, damageType, roomObjects, roomT
         require('./creeps/_clear-newbie-walls')(roomObjects, bulk);
     }
     else if (target.hits <= 0) {
-
-        if(target.type == 'creep') {
-            require('./creeps/_die')(target, roomObjects, bulk, stats);
-        }
-        else {
-
+        if (target.type != 'creep') {
             C.RESOURCES_ALL.forEach(resourceType => {
                 if (target[resourceType] > 0) {
                     require('./creeps/_create-energy')(target.x, target.y, target.room,
@@ -132,10 +127,7 @@ module.exports = function(object, target, damage, damageType, roomObjects, roomT
         damageBody(object, attackBackPower, roomObjects, roomTerrain, bulk);
         object.actionLog.attacked = {x: target.x, y: target.y};
 
-        if(object.hits <= 0) {
-            require('./creeps/_die')(object, roomObjects, bulk, stats);
-        }
-        else {
+        if(object.hits > 0) {
             bulk.update(object, {
                 hits: object.hits,
                 body: object.body,

--- a/src/processor/intents/_damage.js
+++ b/src/processor/intents/_damage.js
@@ -3,43 +3,6 @@ var _ = require('lodash'),
     driver = utils.getDriver(),
     C = driver.constants;
 
-function damageBody(object, damage, roomObjects, roomTerrain, bulk) {
-
-    let damageReduce = 0, damageEffective = damage;
-
-    if(_.any(object.body, i => !!i.boost)) {
-        for(let i=0; i<object.body.length; i++) {
-            if(damageEffective <= 0) {
-                break;
-            }
-            let bodyPart = object.body[i], damageRatio = 1;
-            if(bodyPart.boost && C.BOOSTS[bodyPart.type][bodyPart.boost] && C.BOOSTS[bodyPart.type][bodyPart.boost].damage) {
-                damageRatio = C.BOOSTS[bodyPart.type][bodyPart.boost].damage;
-            }
-            let bodyPartHitsEffective = bodyPart.hits / damageRatio;
-            damageReduce += Math.min(bodyPartHitsEffective, damageEffective) * (1 - damageRatio);
-            damageEffective -= Math.min(bodyPartHitsEffective, damageEffective);
-        }
-    }
-
-    damage -= Math.round(damageReduce);
-
-    object.hits -= damage;
-
-    require('./creeps/_recalc-body')(object);
-
-    for(var i=0; i<C.RESOURCES_ALL.length; i++) {
-        var resourceType = C.RESOURCES_ALL[i];
-        var totalAmount = utils.calcResources(object);
-        if(totalAmount <= object.energyCapacity) {
-            break;
-        }
-        if(object[resourceType]) {
-            require('./creeps/drop')(object, {amount: Math.min(object[resourceType], totalAmount - object.energyCapacity), resourceType}, roomObjects, roomTerrain, bulk);
-        }
-    }
-}
-
 module.exports = function(object, target, damage, damageType, roomObjects, roomTerrain, bulk, roomController, stats, gameTime, roomInfo) {
 
     if(!target.hits) {
@@ -52,7 +15,7 @@ module.exports = function(object, target, damage, damageType, roomObjects, roomT
         if(damageType == 'melee' && !_.any(roomObjects, {type: 'rampart', x: object.x, y: object.y})) {
             attackBackPower = utils.calcBodyEffectiveness(target.body, C.ATTACK, 'attack', C.ATTACK_POWER);
         }
-        damageBody(target, damage, roomObjects, roomTerrain, bulk);
+        target._damageToApply = (target._damageToApply || 0) + damage;
     }
     else {
         target.hits -= damage;
@@ -92,15 +55,7 @@ module.exports = function(object, target, damage, damageType, roomObjects, roomT
         }
     }
     else {
-        if (target.type == 'creep') {
-            bulk.update(target, {
-                hits: target.hits,
-                body: target.body,
-                energy: target.energy,
-                energyCapacity: target.energyCapacity
-            });
-        }
-        else {
+        if (target.type != 'creep') {
             bulk.update(target, {hits: target.hits});
         }
     }
@@ -124,17 +79,8 @@ module.exports = function(object, target, damage, damageType, roomObjects, roomT
     }
 
     if(attackBackPower) {
-        damageBody(object, attackBackPower, roomObjects, roomTerrain, bulk);
+        object._damageToApply = (object._damageToApply || 0) + attackBackPower;
         object.actionLog.attacked = {x: target.x, y: target.y};
-
-        if(object.hits > 0) {
-            bulk.update(object, {
-                hits: object.hits,
-                body: object.body,
-                energy: object.energy,
-                energyCapacity: object.energyCapacity
-            });
-        }
     }
 };
 

--- a/src/processor/intents/creeps/_damage-body.js
+++ b/src/processor/intents/creeps/_damage-body.js
@@ -1,0 +1,32 @@
+var _ = require('lodash'),
+    utils =  require('../../utils'),
+    driver = utils.getDriver(),
+    C = driver.constants;
+
+module.exports = function damageBody(object, damage, roomObjects, roomTerrain, bulk) {
+
+    let damageReduce = 0, damageEffective = damage;
+
+    if(_.any(object.body, i => !!i.boost)) {
+        for(let i=0; i<object.body.length; i++) {
+            if(damageEffective <= 0) {
+                break;
+            }
+            let bodyPart = object.body[i], damageRatio = 1;
+            if(bodyPart.boost && C.BOOSTS[bodyPart.type][bodyPart.boost] && C.BOOSTS[bodyPart.type][bodyPart.boost].damage) {
+                damageRatio = C.BOOSTS[bodyPart.type][bodyPart.boost].damage;
+            }
+            let bodyPartHitsEffective = bodyPart.hits / damageRatio;
+            damageReduce += Math.min(bodyPartHitsEffective, damageEffective) * (1 - damageRatio);
+            damageEffective -= Math.min(bodyPartHitsEffective, damageEffective);
+        }
+    }
+
+    damage -= Math.round(damageReduce);
+
+    object.hits -= damage;
+
+    require('./creeps/_recalc-body')(object);
+
+    require('./creeps/_drop-resources-without-space')(object, roomObjects, roomTerrain, bulk);
+};

--- a/src/processor/intents/creeps/_drop-resources-without-space.js
+++ b/src/processor/intents/creeps/_drop-resources-without-space.js
@@ -1,0 +1,17 @@
+var _ = require('lodash'),
+    utils = require('../../../utils'),
+    driver = utils.getDriver(),
+    C = driver.constants;
+
+module.exports = function dropResourcesWithoutSpace(object, roomObjects, roomTerrain, bulk) {
+    for(var i=0; i<C.RESOURCES_ALL.length; i++) {
+        var resourceType = C.RESOURCES_ALL[i];
+        var totalAmount = utils.calcResources(object);
+        if(totalAmount <= object.energyCapacity) {
+            break;
+        }
+        if(object[resourceType]) {
+            require('./drop')(object, {amount: Math.min(object[resourceType], totalAmount - object.energyCapacity), resourceType}, roomObjects, roomTerrain, bulk);
+        }
+    }
+};

--- a/src/processor/intents/creeps/heal.js
+++ b/src/processor/intents/creeps/heal.js
@@ -25,20 +25,8 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
 
     var healPower = utils.calcBodyEffectiveness(object.body, C.HEAL, 'heal', C.HEAL_POWER);
 
-    target.hits += healPower;
+    target._healToApply = (target._healToApply || 0) + healPower;
 
-    if(target.hits > target.hitsMax) {
-        target.hits = target.hitsMax;
-    }
-
-
-    require('./_recalc-body')(target);
     object.actionLog.heal = {x: target.x, y: target.y};
     target.actionLog.healed = {x: object.x, y: object.y};
-
-    bulk.update(target, {
-        hits: target.hits,
-        body: target.body,
-        energyCapacity: target.energyCapacity
-    });
 };

--- a/src/processor/intents/creeps/heal.js
+++ b/src/processor/intents/creeps/heal.js
@@ -32,7 +32,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
     }
 
 
-    recalcBody(target);
+    require('./_recalc-body')(target);
     object.actionLog.heal = {x: target.x, y: target.y};
     target.actionLog.healed = {x: object.x, y: object.y};
 
@@ -41,10 +41,4 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
         body: target.body,
         energyCapacity: target.energyCapacity
     });
-
-    function recalcBody(object) {
-        require('./_recalc-body')(object);
-    }
-
-
 };

--- a/src/processor/intents/creeps/rangedHeal.js
+++ b/src/processor/intents/creeps/rangedHeal.js
@@ -32,7 +32,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
     }
 
 
-    recalcBody(target);
+    require('./_recalc-body')(target);
     object.actionLog.rangedHeal = {x: target.x, y: target.y};
     target.actionLog.healed = {x: object.x, y: object.y};
 
@@ -41,22 +41,4 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
         body: target.body,
         energyCapacity: target.energyCapacity
     });
-
-    function recalcBody(object) {
-
-        var hits = object.hits;
-
-        for(var i = object.body.length-1; i>=0; i--) {
-            if(hits > 100)
-                object.body[i].hits = 100;
-            else
-                object.body[i].hits = hits;
-            hits -= 100;
-            if(hits < 0) hits = 0;
-        }
-
-        object.energyCapacity = _.filter(object.body, (i) => i.hits > 0 && i.type == C.CARRY).length * C.CARRY_CAPACITY;
-    }
-
-
 };

--- a/src/processor/intents/creeps/rangedHeal.js
+++ b/src/processor/intents/creeps/rangedHeal.js
@@ -25,20 +25,8 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
 
     var healPower = utils.calcBodyEffectiveness(object.body, C.HEAL, 'rangedHeal', C.RANGED_HEAL_POWER);
 
-    target.hits += healPower;
+    target._healToApply = (target._healToApply || 0) + healPower;
 
-    if(target.hits > target.hitsMax) {
-        target.hits = target.hitsMax;
-    }
-
-
-    require('./_recalc-body')(target);
     object.actionLog.rangedHeal = {x: target.x, y: target.y};
     target.actionLog.healed = {x: object.x, y: object.y};
-
-    bulk.update(target, {
-        hits: target.hits,
-        body: target.body,
-        energyCapacity: target.energyCapacity
-    });
 };

--- a/src/processor/intents/creeps/tick.js
+++ b/src/processor/intents/creeps/tick.js
@@ -102,4 +102,14 @@ module.exports = function(object, roomObjects, roomTerrain, bulk, bulkUsers, roo
         require('./_die')(object, roomObjects, bulk, stats);
     }
 
+    if(object._damageToApply) {
+        require('./_damage-body')(object, object._damageToApply, roomObjects, roomTerrain, bulk);
+        delete object._damageToApply;
+
+        bulk.update(object, {
+            hits: object.hits,
+            body: object.body,
+            energyCapacity: object.energyCapacity
+        });
+    }
 };

--- a/src/processor/intents/creeps/tick.js
+++ b/src/processor/intents/creeps/tick.js
@@ -94,7 +94,7 @@ module.exports = function(object, roomObjects, roomTerrain, bulk, bulkUsers, roo
         bulk.update(object._id, {fatigue: object.fatigue});
     }
 
-    if(_.isNaN(object.hits)) {
+    if(_.isNaN(object.hits) || object.hits <= 0) {
         require('./_die')(object, roomObjects, bulk, stats);
     }
 

--- a/src/processor/intents/creeps/tick.js
+++ b/src/processor/intents/creeps/tick.js
@@ -102,7 +102,24 @@ module.exports = function(object, roomObjects, roomTerrain, bulk, bulkUsers, roo
         require('./_die')(object, roomObjects, bulk, stats);
     }
 
-    if(object._damageToApply) {
+    if (object._healToApply) {
+        object.hits += object._healToApply;
+        if (object.hits > object.hitsMax) {
+            object.hits = object.hitsMax;
+        }
+
+        require('./_recalc-body')(object);
+
+        bulk.update(object, {
+            hits: object.hits,
+            body: object.body,
+            energyCapacity: object.energyCapacity,
+        });
+
+        delete object._healToApply;
+    }
+
+    if (object._damageToApply) {
         require('./_damage-body')(object, object._damageToApply, roomObjects, roomTerrain, bulk);
         delete object._damageToApply;
 

--- a/src/processor/intents/spawns/renew-creep.js
+++ b/src/processor/intents/spawns/renew-creep.js
@@ -46,6 +46,8 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
             i.boost = null;
         });
         require('../creeps/_recalc-body')(target);
+        // we may not be able to hold all of the resources we could before now.
+        require('../creeps/_drop-resources-without-space')(target, roomObjects, roomTerrain, bulk);
         bulk.update(target, {body: target.body, energyCapacity: target.energyCapacity});
     }
 

--- a/src/processor/intents/towers/heal.js
+++ b/src/processor/intents/towers/heal.js
@@ -40,19 +40,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
         return;
     }
 
-    target.hits += effect;
-
-    if(target.hits > target.hitsMax) {
-        target.hits = target.hitsMax;
-    }
-
-    require('../creeps/_recalc-body')(target);
-
-    bulk.update(target, {
-        hits: target.hits,
-        body: target.body,
-        energyCapacity: target.energyCapacity
-    });
+    target._healToApply = (target._healToApply || 0) + effect;
 
     object.energy -= C.TOWER_ENERGY_COST;
     bulk.update(object, {energy: object.energy});


### PR DESCRIPTION
This conflicts with #15, either one or the other should be merged.

This fixes some essentially psuedo-random behavior, and makes sure that heal operations only ever heal damage that existed at the start of the tick.

See http://support.screeps.com/hc/en-us/community/posts/115000234225-Overhealing-vs-strictly-healing-past-damage-fixing-inconsistencies-based-off-of-intent-order for more information / discussion.