### PR TITLE
Optimizations for utils.checkStructureAgainstController

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -840,38 +840,38 @@ exports.sendAttackingNotification = function(target, roomController) {
 
 exports.checkStructureAgainstController = function(object, roomObjects, roomController) {
     // owner-less objects are always active
-    if (!object.user) {
+    if(!object.user) {
         return true;
     }
 
     // eliminate some other easy cases
-    if (!roomController || roomController.level < 1 || roomController.user !== object.user) {
+    if(!roomController || roomController.level < 1 || roomController.user !== object.user) {
         return false;
     }
 
     let allowedRemaining = C.CONTROLLER_STRUCTURES[object.type][roomController.level];
     
     // if only one object ever allowed, this is it
-    if (C.CONTROLLER_STRUCTURES[object.type][8] === 1) {
+    if(C.CONTROLLER_STRUCTURES[object.type][8] === 1) {
         return allowedRemaining !== 0;
     }
 
     // Scan through the room objects of the same type and count how many are closer. 
     let foundSelf = false;
     let objectDist = Math.max(Math.abs(object.x - roomController.x), Math.abs(object.y - roomController.y));
-    for (let i = 0; i < roomObjects.length; i++) {
+    for(let i = 0; i < roomObjects.length; i++) {
         let compareObj = roomObjects[i];
-        if (compareObj.type === object.type && compareObj.user === object.user) {
+        if(compareObj.type === object.type && compareObj.user === object.user) {
             let compareDist = Math.max(Math.abs(compareObj.x - roomController.x), Math.abs(compareObj.y - roomController.y));
             
-            if (compareDist < objectDist) {
+            if(compareDist < objectDist) {
                 allowedRemaining--;
                 if (allowedRemaining === 0) {
                     return false;
                 }
-            } else if (!foundSelf && compareDist === objectDist) {
+            } else if(!foundSelf && compareDist === objectDist) {
                 // Objects of equal distance that are discovered before we scan over the selected object are considered closer
-                if (object === compareObj) {
+                if(object === compareObj) {
                     foundSelf = true;
                 } else {
                     allowedRemaining--;

--- a/src/utils.js
+++ b/src/utils.js
@@ -839,28 +839,50 @@ exports.sendAttackingNotification = function(target, roomController) {
 };
 
 exports.checkStructureAgainstController = function(object, roomObjects, roomController) {
-
-    if(!object.user) {
+    // owner-less objects are always active
+    if (!object.user) {
         return true;
     }
 
-    if(!roomController || roomController.level < 1 || object.user && roomController.user != object.user) {
+    // eliminate some other easy cases
+    if (!roomController || roomController.level < 1 || roomController.user !== object.user) {
         return false;
     }
 
-    if(C.CONTROLLER_STRUCTURES[object.type][8] == 1) {
-        return C.CONTROLLER_STRUCTURES[object.type][roomController.level] != 0;
+    let allowedRemaining = C.CONTROLLER_STRUCTURES[object.type][roomController.level];
+    
+    // if only one object ever allowed, this is it
+    if (C.CONTROLLER_STRUCTURES[object.type][8] === 1) {
+        return allowedRemaining !== 0;
     }
 
-    var objects = _.filter(roomObjects, {type: object.type, user: object.user});
-
-    if(objects.length > C.CONTROLLER_STRUCTURES[object.type][roomController.level]) {
-        objects.sort(exports.comparatorDistance(roomController));
-        objects = _.take(objects, C.CONTROLLER_STRUCTURES[object.type][roomController.level]);
-        if(!_.contains(objects, object)) {
-            return false;
+    // Scan through the room objects of the same type and count how many are closer. 
+    let foundSelf = false;
+    let objectDist = Math.max(Math.abs(object.x - roomController.x), Math.abs(object.y - roomController.y));
+    for (let i = 0; i < roomObjects.length; i++) {
+        let compareObj = roomObjects[i];
+        if (compareObj.type === object.type && compareObj.user === object.user) {
+            let compareDist = Math.max(Math.abs(compareObj.x - roomController.x), Math.abs(compareObj.y - roomController.y));
+            
+            if (compareDist < objectDist) {
+                allowedRemaining--;
+                if (allowedRemaining === 0) {
+                    return false;
+                }
+            } else if (!foundSelf && compareDist === objectDist) {
+                // Objects of equal distance that are discovered before we scan over the selected object are considered closer
+                if (object === compareObj) {
+                    foundSelf = true;
+                } else {
+                    allowedRemaining--;
+                    if (allowedRemaining === 0) {
+                        return false;
+                    }
+                }
+            }
         }
     }
+    
     return true;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -859,8 +859,9 @@ exports.checkStructureAgainstController = function(object, roomObjects, roomCont
     // Scan through the room objects of the same type and count how many are closer. 
     let foundSelf = false;
     let objectDist = Math.max(Math.abs(object.x - roomController.x), Math.abs(object.y - roomController.y));
-    for(let i = 0; i < roomObjects.length; i++) {
-        let compareObj = roomObjects[i];
+    let objectIds = _.keys(roomObjects);
+    for (let i = 0; i < objectIds.length; i++) {
+        let compareObj = roomObjects[objectIds[i]];
         if(compareObj.type === object.type && compareObj.user === object.user) {
             let compareDist = Math.max(Math.abs(compareObj.x - roomController.x), Math.abs(compareObj.y - roomController.y));
             


### PR DESCRIPTION
Replaced the calls to _.sort and _.take with a loop that instead counts how many same-type objects are closer.

Validated by executing on all objects in the W5xS0x sector and comparing the result against the original function, simulating each controller level. The results were consistent in all cases *except* when the original QuickSort had side effects and shuffled around objects with the same controller distance.

Perf test suggests the refactored version executes 6.6x as quickly.