### PR TITLE
Add body part check to claimController processor

### DIFF
--- a/src/processor/intents/creeps/claimController.js
+++ b/src/processor/intents/creeps/claimController.js
@@ -25,6 +25,9 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
     if(target.level > 0) {
         return;
     }
+    if ((_.filter(object.body, (i) => i.hits > 0 && i.type == C.CLAIM).length) === 0) {
+        return;
+    }
     if(target.reservation && target.reservation.user != object.user) {
         return;
     }


### PR DESCRIPTION
This fixes an unintended behaviour where the server side check for `CLAIM` body parts is missing for the `claimController` processor. It can easily be tested, where you can unclaim your controller and claim it with a single `MOVE` creep.

Try the following code and check the results.
```
Creep.prototype.nativeGetActiveBodyParts = Creep.prototype.getActiveBodyparts;
Creep.prototype.getActiveBodyparts = function(part) {
    if (part === CLAIM) {
        return 5;
    }
    return this.nativeGetActiveBodyParts(part);
};

module.exports.loop = function loop() {
    const room = _.first(_.values(Game.rooms));

    const creep = _.first(_.values(Game.creeps));

    if (!creep) {
        const spawn = _.first(room.find(FIND_MY_STRUCTURES, {
            filter: ({structureType}) => structureType === STRUCTURE_SPAWN
        }));

        spawn.createCreep([MOVE]);
        return;
    }

    const controller = room.controller;

    if (controller.owner) {
        controller.unclaim();
    } else {
        if (creep.claimController(controller) === ERR_NOT_IN_RANGE) {
            creep.moveTo(controller);
        }
    }
};
```