### PR TITLE
Expose Game.setIntent

### DIFF
--- a/src/game/game.js
+++ b/src/game/game.js
@@ -148,6 +148,10 @@
             getObjectById(id) {
                 return register._objects[id] || null;
             },
+            setIntent(id, action, args) {
+                intents.set(id, action, args);
+                return C.OK;
+            },
             notify(message, groupInterval) {
                 if (intents.push('notify', {message, groupInterval}, 20)) {
                     return C.OK;


### PR DESCRIPTION
This allows users to use an alternate style of interacting with the game API, such as a functional approach like:

```javascript
_(Game.creeps).map(creepBrain)
              .reduce(Game.setIntent);
```

Where creepBrain is a function from Creep -> intended action (In the form of a triple: `[id, name, arguments]`).

Security-wise there shouldn't be a problem with this, since the latter processing of intents needs to be secure by itself.

It would also be interesting to allow users to opt-out of having the various Game objects created for them (Which takes a bit of time I assume -- though the player doesn't pay for that), instead using just the raw data.