### PR TITLE
Fix: don't renew spawning creeps

### DIFF
--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -1140,6 +1140,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!target.pos.isNearTo(this.pos)) {
             return C.ERR_NOT_IN_RANGE;
         }
+        if(target.spawning) {
+            return C.ERR_INVALID_TARGET;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }

--- a/src/processor/intents/spawns/renew-creep.js
+++ b/src/processor/intents/spawns/renew-creep.js
@@ -13,7 +13,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
     }
 
     var target = roomObjects[intent.id];
-    if(!target || target.type != 'creep' || target.user != object.user) {
+    if(!target || target.type != 'creep' || target.user != object.user || target.spawning) {
         return;
     }
     if(Math.abs(target.x - object.x) > 1 || Math.abs(target.y - object.y) > 1) {


### PR DESCRIPTION
This should fix the following bug report: http://support.screeps.com/hc/en-us/community/posts/115000559889-Renewing-kills-unspawned-creeps

Can't test the fix right now, but the syntax matches the one used in other intends. Not sure if the check in the API function itself is wanted like that.
