### PR TITLE
Fix: don't renew spawning creeps

### DIFF
--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -1134,7 +1134,7 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
-        if(!target || !target.id || !register.creeps[target.id] || !(target instanceof globals.Creep)) {
+        if(!target || !target.id || !register.creeps[target.id] || !(target instanceof globals.Creep) || target.spawning) {
             register.assertTargetObject(target);
             return C.ERR_INVALID_TARGET;
         }

--- a/src/processor/intents/spawns/renew-creep.js
+++ b/src/processor/intents/spawns/renew-creep.js
@@ -13,7 +13,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk, bulkUs
     }
 
     var target = roomObjects[intent.id];
-    if(!target || target.type != 'creep' || target.user != object.user) {
+    if(!target || target.type != 'creep' || target.user != object.user || target.spawning) {
         return;
     }
     if(Math.abs(target.x - object.x) > 1 || Math.abs(target.y - object.y) > 1) {


### PR DESCRIPTION
This should fix the following reported bug: http://support.screeps.com/hc/en-us/community/posts/115000559889-Renewing-kills-unspawned-creeps

Can't test the fix right now, but the syntax matches the one used in the API and intend for recycleCreep.

(Disregard the closed pull request of the same name. I messed up)