### PR TITLE
Fix ConstructionSite destruction in safeModed room

### DIFF
--- a/src/processor/intents/movement.js
+++ b/src/processor/intents/movement.js
@@ -171,7 +171,7 @@ exports.execute = function(object, bulk, roomController, gameTime) {
         bulk.update(road, {nextDecayTime: road.nextDecayTime});
     }
 
-    if(!roomController || !(roomController.safeMode > gameTime)) {
+    if(!roomController || roomController.user === object.user || !(roomController.safeMode > gameTime)) {
         var constructionSite = _.find(ceilObjects, (i) => i.type == 'constructionSite' && i.user != object.user);
         if (constructionSite) {
             require('./construction-sites/remove')(constructionSite, roomObjects, bulk);


### PR DESCRIPTION
This will allow the owner of a room to destroy ConstructionSites by stepping on them, even if the room is in safe mode.
The bug was especially irritating for new players spawning in an abandoned room, because it made them unable to place any construction sites, when their controller level isn't sufficient to support both the hostile and the own construction sites. A separate pull request might get filed to change this behaviour as well.