### PR TITLE
Fix withdrawing from PowerSpawn

### DIFF
--- a/src/game/creeps.js
+++ b/src/game/creeps.js
@@ -624,7 +624,7 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
             if(!amount) {
                 amount = Math.min( data(target.id)[resourceType], emptySpace );
             }
-            if(data(target.id)[resourceType] || data(target.id)[resourceType] < amount) {
+            if(!data(target.id)[resourceType] || data(target.id)[resourceType] < amount) {
                 return C.ERR_NOT_ENOUGH_RESOURCES;
             }
             if(amount > emptySpace) {


### PR DESCRIPTION
This resolves the bug reported http://support.screeps.com/hc/en-us/community/posts/115002185869-bug-in-src-game-creeps-js-withdrawing-from-power-spawn

Allowing withdrawing from PowerSpawn similarly to other structures.

However looking at the code it raises the question: Why is PowerSpawn considered separately at all?