### PR TITLE
Fix ConstructionSite interaction in safemode

### DIFF
--- a/src/processor/intents/movement.js
+++ b/src/processor/intents/movement.js
@@ -171,11 +171,11 @@ exports.execute = function(object, bulk, roomController, gameTime) {
         bulk.update(road, {nextDecayTime: road.nextDecayTime});
     }
 
-    if(!roomController || !(roomController.safeMode > gameTime)) {
-        var constructionSite = _.find(ceilObjects, (i) => i.type == 'constructionSite' && i.user != object.user);
-        if (constructionSite) {
-            require('./construction-sites/remove')(constructionSite, roomObjects, bulk);
-        }
+    var isInSafeMode = roomController && roomController.safeMode > gameTime;
+    
+    var constructionSite = _.find(ceilObjects, (i) => i.type == 'constructionSite' && i.user != object.user && !isInSafeMode || (roomController && roomController.user != i.user));
+    if (constructionSite) {
+        require('./construction-sites/remove')(constructionSite, roomObjects, bulk);
     }
 
     var fatigue = _(object.body).filter((i) => i.type != C.MOVE && i.type != C.CARRY).size();


### PR DESCRIPTION
This changes makes it possible for an owner of a room to destroy hostile ConstructionSites even if his room is in safemode.
The bug was especially irritating for new players spawning in an abandoned room, because it made them unable to place any construction sites, when their controller level isn't sufficient to support both the hostile and the own construction sites. A separate pull request might get filed to change this behaviour as well.