### PR TITLE
check if extension/spawn is owned by room owner

### DIFF
--- a/src/game/game.js
+++ b/src/game/game.js
@@ -283,7 +283,7 @@
                 }
 
             }
-            if (!object.off && (object.type == 'extension' || object.type == 'spawn')) {
+            if (!object.off && object.owner == object.room.controller.owner && (object.type == 'extension' || object.type == 'spawn')) {
                 register.rooms[object.room].energyAvailable += object.energy;
                 register.rooms[object.room].energyCapacityAvailable += object.energyCapacity;
             }


### PR DESCRIPTION
needs testing.  did on the fly.  dont know how to test this.

To give correct energyAvailable & energyCapacityAvailable because currently if hostile extensions in room then count towards total.