### PR TITLE
Fix for boosting creeps with CLAIM parts

### DIFF
--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -485,7 +485,7 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
             return C.ERR_NOT_ENOUGH_RESOURCES;
         }
         bodyPartsCount = bodyPartsCount || 0;
-        var nonBoostedParts = _(target.body).filter(i => !i.boost && C.BOOSTS[i.type][data(this.id).mineralType]).size();
+        var nonBoostedParts = _(target.body).filter(i => !i.boost && C.BOOSTS[i.type] && C.BOOSTS[i.type][data(this.id).mineralType]).size();
 
         if(!nonBoostedParts || bodyPartsCount && bodyPartsCount > nonBoostedParts) {
             return C.ERR_NOT_FOUND;

--- a/src/processor/intents/labs/boost-creep.js
+++ b/src/processor/intents/labs/boost-creep.js
@@ -17,7 +17,7 @@ module.exports = function(object, intent, roomObjects, roomTerrain, bulk) {
         return;
     }
 
-    var nonBoostedParts = _.filter(target.body, i => !i.boost && C.BOOSTS[i.type][object.mineralType]);
+    var nonBoostedParts = _.filter(target.body, i => !i.boost && C.BOOSTS[i.type] && C.BOOSTS[i.type][object.mineralType]);
 
     if(!nonBoostedParts.length) {
         return;


### PR DESCRIPTION
Bug report for reference: http://support.screeps.com/hc/en-us/community/posts/115004286513-exception-with-boosting-creeps-with-CLAIM-parts

This change excludes unboostable parts from the list of `nonBoostedParts`.