### PR TITLE
Prevent deal amounts from changing due to rounding

### DIFF
--- a/src/processor/market.js
+++ b/src/processor/market.js
@@ -299,9 +299,11 @@ module.exports.execute = function(market, gameTime, terminals, bulkObjects) {
             var dealCost = utils.roundCredits(amount * order.price);
 
             if(buyer.user) {
-                dealCost = Math.min(dealCost, usersById[buyer.user].money || 0);
-                amount = Math.floor(dealCost/order.price);
-                dealCost = utils.roundCredits(amount * order.price);
+                var money = usersById[buyer.user].money || 0;
+                if (dealCost > money) {
+                    amount = Math.floor(money/order.price);
+                    dealCost = utils.roundCredits(amount * order.price);
+                }
                 if(!amount) {
                     return;
                 }


### PR DESCRIPTION
This fixes a bug that is causing orders that had a total deal cost where the digit in the thousandth place is between 1 and 4 from fulfilling the full amount.  Drycoded/untested.

Test case: Quantity: 999 Price: 0.236
Assumption: Buyer has the credits required to complete the transaction.

Current code: Makes a transaction for quantity of 998, which is 1 short of the amount requested.
Proposed code: Makes a transaction for quantity of 999.