### PR TITLE
creep in room corner moves to diagonal adjacent room

### DIFF
--- a/src/processor/intents/creeps/tick.js
+++ b/src/processor/intents/creeps/tick.js
@@ -55,19 +55,19 @@ module.exports = function(object, roomObjects, roomTerrain, bulk, bulkUsers, roo
                 y = object.y,
                 room = object.room;
 
-            if (object.x == 0) {
+            if (x == 0) {
                 x = 49;
                 roomX = roomX - 1;
             }
-            else if (object.x == 49) {
+            else if (x == 49) {
                 x = 0;
                 roomX = roomX + 1;
             }
-            if (object.y == 0) {
+            if (y == 0) {
                 y = 49;
                 roomY = roomY - 1;
             }
-            else if (object.y == 49) {
+            else if (y == 49) {
                 y = 0;
                 roomY = roomY + 1;
             }

--- a/src/processor/intents/creeps/tick.js
+++ b/src/processor/intents/creeps/tick.js
@@ -57,20 +57,21 @@ module.exports = function(object, roomObjects, roomTerrain, bulk, bulkUsers, roo
 
             if (object.x == 0) {
                 x = 49;
-                room = utils.getRoomNameFromXY(roomX-1, roomY);
-            }
-            else if (object.y == 0) {
-                y = 49;
-                room = utils.getRoomNameFromXY(roomX, roomY-1);
+                roomX = roomX - 1;
             }
             else if (object.x == 49) {
                 x = 0;
-                room = utils.getRoomNameFromXY(roomX+1, roomY);
+                roomX = roomX + 1;
+            }
+            if (object.y == 0) {
+                y = 49;
+                roomY = roomY - 1;
             }
             else if (object.y == 49) {
                 y = 0;
-                room = utils.getRoomNameFromXY(roomX, roomY+1);
+                roomY = roomY + 1;
             }
+            room = utils.getRoomNameFromXY(roomX, roomY);
 
             bulk.update(object, {interRoom: {room, x, y}});
         }


### PR DESCRIPTION
The default map generator doesn't allow rooms to have open corners, but that's no reason for this code to be lazy. If a creep is in the corner, it should move to the diagonally adjacent room.