### PR TITLE
Configurable spawning direction

### DIFF
--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -910,7 +910,8 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         name: (o) => o.user == runtimeData.user._id ? o.name : undefined,
         energy: (o) => o.energy,
         energyCapacity: (o) => o.energyCapacity,
-        spawning: (o) => o.spawning || null
+        spawning: (o) => o.spawning || null,
+        spawnDirections: (o) => o.user == runtimeData.user._id ? o.spawnDirections : undefined
     });
 
     Object.defineProperty(StructureSpawn.prototype, 'memory', {
@@ -1350,6 +1351,22 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         intents.set(this.id, 'recycleCreep', {id: target.id});
         return C.OK;
+    });
+
+    StructureSpawn.prototype.setSpawnDirections = register.wrapFn(function(spawnDirections) {
+        if(!this.my) {
+            return C.ERR_NOT_OWNER;
+        }
+        if(_.isArray(spawnDirections) && spawnDirections.length > 0) {
+            // convert directions to numbers, eliminate duplicates
+            spawnDirections = _.uniq(_.map(spawnDirections, e => +e));
+            // bail if any numbers are out of bounds or non-integers
+            if(!_.any(spawnDirections, (direction)=>direction < 1 || direction > 8 || direction !== (direction | 0))) {
+                intents.set(this.id, 'setSpawnDirections', {spawnDirections});
+                return C.OK;
+            }
+        }
+        return C.ERR_INVALID_ARGS;
     });
 
     globals.StructureSpawn = StructureSpawn;

--- a/src/processor/intents/spawns/_born-creep.js
+++ b/src/processor/intents/spawns/_born-creep.js
@@ -9,10 +9,10 @@ module.exports = function(spawn, creep, roomObjects, roomTerrain, bulk, stats) {
     var newX, newY, isOccupied, hostileOccupied;
     var checkObstacleFn = (i) => _.contains(C.OBSTACLE_OBJECT_TYPES, i.type) && i.x == newX && i.y == newY;
 
-    const spawnDirections = spawn.spawning.spawnDirections || spawn.spawnDirections || [1,2,3,4,5,6,7,8];
-    const otherDirections = _.difference([1,2,3,4,5,6,7,8], spawnDirections);
+    const directions = spawn.spawning.directions || [1,2,3,4,5,6,7,8];
+    const otherDirections = _.difference([1,2,3,4,5,6,7,8], directions);
     // find the first direction where the creep can spawn
-    for (var direction of spawnDirections) {
+    for (var direction of directions) {
         var [dx,dy] = utils.getOffsetsByDirection(direction);
 
         newX = spawn.x + dx;
@@ -41,23 +41,23 @@ module.exports = function(spawn, creep, roomObjects, roomTerrain, bulk, stats) {
         return true;
     }
 
-    // bail if there's an opening we could spawn to but chose not to
-    for (var direction of otherDirections) {
-        var [dx,dy] = utils.getOffsetsByDirection(direction);
-
-        newX = spawn.x + dx;
-        newY = spawn.y + dy;
-        isOccupied = _.any(roomObjects, checkObstacleFn) ||
-            utils.checkTerrain(roomTerrain, newX, newY, C.TERRAIN_MASK_WALL) ||
-            movement.isTileBusy(newX, newY);
-
-        if (!isOccupied) {
-            return false;
-        }
-    }
-
-    // spawn is surrounded, spawnstomp the first hostile we found above
+    // spawn is surrounded, spawnstomp the first hostile we found above, unless...
     if(hostileOccupied) {
+        // bail if there's an opening we could spawn to but chose not to
+        for (var direction of otherDirections) {
+            var [dx,dy] = utils.getOffsetsByDirection(direction);
+
+            newX = spawn.x + dx;
+            newY = spawn.y + dy;
+            isOccupied = _.any(roomObjects, checkObstacleFn) ||
+                utils.checkTerrain(roomTerrain, newX, newY, C.TERRAIN_MASK_WALL) ||
+                movement.isTileBusy(newX, newY);
+
+            if (!isOccupied) {
+                return false;
+            }
+        }
+
         require('../creeps/_die')(hostileOccupied, roomObjects, bulk, stats);
         bulk.update(creep, {
             x: hostileOccupied.x,

--- a/src/processor/intents/spawns/_born-creep.js
+++ b/src/processor/intents/spawns/_born-creep.js
@@ -9,7 +9,10 @@ module.exports = function(spawn, creep, roomObjects, roomTerrain, bulk, stats) {
     var newX, newY, isOccupied, hostileOccupied;
     var checkObstacleFn = (i) => _.contains(C.OBSTACLE_OBJECT_TYPES, i.type) && i.x == newX && i.y == newY;
 
-    for (var direction = 1; direction <= 8; direction++) {
+    const spawnDirections = spawn.spawning.spawnDirections || spawn.spawnDirections || [1,2,3,4,5,6,7,8];
+    const otherDirections = _.difference([1,2,3,4,5,6,7,8], spawnDirections);
+    // find the first direction where the creep can spawn
+    for (var direction of spawnDirections) {
         var [dx,dy] = utils.getOffsetsByDirection(direction);
 
         newX = spawn.x + dx;
@@ -22,11 +25,13 @@ module.exports = function(spawn, creep, roomObjects, roomTerrain, bulk, stats) {
             break;
         }
 
+        // remember the first direction where we found a hostile creep
         if(!hostileOccupied) {
             hostileOccupied = _.find(roomObjects, i => i.x == newX && i.y == newY && i.type == 'creep' && i.user != spawn.user);
         }
     }
 
+    // if we found a place to spawn, do so
     if(!isOccupied) {
         bulk.update(creep, {
             x: newX,
@@ -35,7 +40,24 @@ module.exports = function(spawn, creep, roomObjects, roomTerrain, bulk, stats) {
         });
         return true;
     }
-    else if(hostileOccupied) {
+
+    // bail if there's an opening we could spawn to but chose not to
+    for (var direction of otherDirections) {
+        var [dx,dy] = utils.getOffsetsByDirection(direction);
+
+        newX = spawn.x + dx;
+        newY = spawn.y + dy;
+        isOccupied = _.any(roomObjects, checkObstacleFn) ||
+            utils.checkTerrain(roomTerrain, newX, newY, C.TERRAIN_MASK_WALL) ||
+            movement.isTileBusy(newX, newY);
+
+        if (!isOccupied) {
+            return false;
+        }
+    }
+
+    // spawn is surrounded, spawnstomp the first hostile we found above
+    if(hostileOccupied) {
         require('../creeps/_die')(hostileOccupied, roomObjects, bulk, stats);
         bulk.update(creep, {
             x: hostileOccupied.x,

--- a/src/processor/intents/spawns/create-creep.js
+++ b/src/processor/intents/spawns/create-creep.js
@@ -16,16 +16,16 @@ module.exports = function(spawn, intent, roomObjects, roomTerrain, bulk, bulkUse
         return;
     }
 
-    let spawnDirections = intent.spawnDirections;
-    if(spawnDirections !== undefined) {
-        if(!_.isArray(spawnDirections)) {
+    let directions = intent.directions;
+    if(directions !== undefined) {
+        if(!_.isArray(directions)) {
             return;
         }
         // convert directions to numbers, eliminate duplicates
-        spawnDirections = _.uniq(_.map(spawnDirections, e => +e));
-        if(spawnDirections.length > 0) {
+        directions = _.uniq(_.map(directions, e => +e));
+        if(directions.length > 0) {
             // bail if any numbers are out of bounds or non-integers
-            if(!_.all(spawnDirections, direction => direction >= 1 && direction <= 8 && direction === (direction | 0))) {
+            if(!_.all(directions, direction => direction >= 1 && direction <= 8 && direction === (direction | 0))) {
                 return;
             }
         }
@@ -46,10 +46,11 @@ module.exports = function(spawn, intent, roomObjects, roomTerrain, bulk, bulkUse
 
     bulk.update(spawn, {
         spawning: {
+            spawnId: spawn._id,
             name: intent.name,
             needTime: C.CREEP_SPAWN_TIME * intent.body.length,
             remainingTime: C.CREEP_SPAWN_TIME * intent.body.length,
-            spawnDirections
+            directions
         }
     });
 

--- a/src/processor/intents/spawns/create-creep.js
+++ b/src/processor/intents/spawns/create-creep.js
@@ -16,6 +16,21 @@ module.exports = function(spawn, intent, roomObjects, roomTerrain, bulk, bulkUse
         return;
     }
 
+    let spawnDirections = intent.spawnDirections;
+    if(spawnDirections !== undefined) {
+        if(!_.isArray(spawnDirections)) {
+            return;
+        }
+        // convert directions to numbers, eliminate duplicates
+        spawnDirections = _.uniq(_.map(spawnDirections, e => +e));
+        if(spawnDirections.length > 0) {
+            // bail if any numbers are out of bounds or non-integers
+            if(!_.all(spawnDirections, direction => direction >= 1 && direction <= 8 && direction === (direction | 0))) {
+                return;
+            }
+        }
+    }
+
     intent.body = intent.body.slice(0, C.MAX_CREEP_SIZE);
 
     var cost = utils.calcCreepCost(intent.body);
@@ -33,7 +48,8 @@ module.exports = function(spawn, intent, roomObjects, roomTerrain, bulk, bulkUse
         spawning: {
             name: intent.name,
             needTime: C.CREEP_SPAWN_TIME * intent.body.length,
-            remainingTime: C.CREEP_SPAWN_TIME * intent.body.length
+            remainingTime: C.CREEP_SPAWN_TIME * intent.body.length,
+            spawnDirections
         }
     });
 

--- a/src/processor/intents/spawns/intents.js
+++ b/src/processor/intents/spawns/intents.js
@@ -12,4 +12,7 @@ module.exports = function(object, objectIntents, roomObjects, roomTerrain, bulk,
     if(objectIntents.recycleCreep)
         require('./recycle-creep')(object, objectIntents.recycleCreep, roomObjects, roomTerrain, bulk, bulkUsers, roomController, stats, gameTime);
 
+    if(objectIntents.setSpawnDirections)
+        require('./set-spawn-directions')(object, objectIntents.setSpawnDirections, roomObjects, roomTerrain, bulk);
+
 };

--- a/src/processor/intents/spawns/set-spawn-directions.js
+++ b/src/processor/intents/spawns/set-spawn-directions.js
@@ -1,0 +1,18 @@
+var _ = require('lodash'),
+    utils =  require('../../../utils'),
+    driver = utils.getDriver(),
+    C = driver.constants;
+
+module.exports = function(spawn, intent, roomObjects, roomTerrain, bulk) {
+    if(spawn.type != 'spawn')
+        return;
+    const spawnDirections = intent.spawnDirections;
+    if(_.isArray(spawnDirections) && spawnDirections.length > 0) {
+        // convert directions to numbers, eliminate duplicates
+        spawnDirections = _.uniq(_.map(spawnDirections, e => +e));
+        // bail if any numbers are out of bounds or non-integers
+        if(!_.any(spawnDirections, (direction)=>direction < 1 || direction > 8 || direction !== (direction | 0))) {
+            bulk.update(spawn, {spawnDirections});
+        }
+    }
+};

--- a/src/processor/intents/spawns/set-spawn-directions.js
+++ b/src/processor/intents/spawns/set-spawn-directions.js
@@ -6,13 +6,13 @@ var _ = require('lodash'),
 module.exports = function(spawn, intent, roomObjects, roomTerrain, bulk) {
     if(spawn.type != 'spawn')
         return;
-    const spawnDirections = intent.spawnDirections;
-    if(_.isArray(spawnDirections) && spawnDirections.length > 0) {
+    var directions = intent.directions;
+    if(_.isArray(directions) && directions.length > 0) {
         // convert directions to numbers, eliminate duplicates
-        spawnDirections = _.uniq(_.map(spawnDirections, e => +e));
+        directions = _.uniq(_.map(directions, e => +e));
         // bail if any numbers are out of bounds or non-integers
-        if(!_.any(spawnDirections, (direction)=>direction < 1 || direction > 8 || direction !== (direction | 0))) {
-            bulk.update(spawn, {spawnDirections});
+        if(!_.any(directions, (direction)=>direction < 1 || direction > 8 || direction !== (direction | 0))) {
+            bulk.update(spawn, {spawning:{directions}});
         }
     }
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -805,6 +805,11 @@ exports.storeIntents = function(userId, userIntents, userRuntimeData) {
                 sign: (""+objectIntentsResult.signController.sign).substring(0,100)
             };
         }
+        if(objectIntentsResult.setSpawnDirections) {
+            objectIntents.setSpawnDirections = {
+                spawnDirections: objectIntentsResult.setSpawnDirections.spawnDirections
+            };
+        }
 
 
         for(var iCustomType in driver.config.customIntentTypes) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -665,7 +665,8 @@ exports.storeIntents = function(userId, userIntents, userRuntimeData) {
             objectIntents.createCreep = {
                 name: ""+objectIntentsResult.createCreep.name,
                 body: _.filter(objectIntentsResult.createCreep.body, (i) => _.contains(C.BODYPARTS_ALL, i)),
-                energyStructures: objectIntentsResult.createCreep.energyStructures
+                energyStructures: objectIntentsResult.createCreep.energyStructures,
+                spawnDirections: objectIntentsResult.createCreep.spawnDirections
             };
         }
         if(objectIntentsResult.renewCreep) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -666,7 +666,7 @@ exports.storeIntents = function(userId, userIntents, userRuntimeData) {
                 name: ""+objectIntentsResult.createCreep.name,
                 body: _.filter(objectIntentsResult.createCreep.body, (i) => _.contains(C.BODYPARTS_ALL, i)),
                 energyStructures: objectIntentsResult.createCreep.energyStructures,
-                spawnDirections: objectIntentsResult.createCreep.spawnDirections
+                directions: objectIntentsResult.createCreep.directions
             };
         }
         if(objectIntentsResult.renewCreep) {
@@ -808,7 +808,7 @@ exports.storeIntents = function(userId, userIntents, userRuntimeData) {
         }
         if(objectIntentsResult.setSpawnDirections) {
             objectIntents.setSpawnDirections = {
-                spawnDirections: objectIntentsResult.setSpawnDirections.spawnDirections
+                directions: objectIntentsResult.setSpawnDirections.directions
             };
         }
 


### PR DESCRIPTION
Allow the script to specify on a per-Spawn and per-spawnCreep() basis which direction(s) the creep should pop out at, instead of always trying north, northeast, etc.

If every selected direction is full then the same thing happens as when the spawn is surrounded, except that enemy creeps only die if there aren't any open unselected directions (so you can still only spawnstomp if you're actually surrounded).