### PR TITLE
Allow `swampCost` and `plainCost` as options in _findPath2

### DIFF
--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -255,6 +255,12 @@ function _findPath2(id, fromPos, toPos, opts) {
         searchOpts.plainCost = 2;
         searchOpts.swampCost = 10;
     }
+    if(!opts.plainCost) {
+        searchOpts.plainCost = opts.plainCost;
+    }
+    if(!opts.swampCost) {
+        searchOpts.swampCost = opts.swampCost;
+    }
 
     var ret = globals.PathFinder.search(fromPos, {range: Math.max(1,opts.range || 0), pos: toPos}, searchOpts);
 

--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -255,10 +255,10 @@ function _findPath2(id, fromPos, toPos, opts) {
         searchOpts.plainCost = 2;
         searchOpts.swampCost = 10;
     }
-    if(!opts.plainCost) {
+    if(opts.plainCost) {
         searchOpts.plainCost = opts.plainCost;
     }
-    if(!opts.swampCost) {
+    if(opts.swampCost) {
         searchOpts.swampCost = opts.swampCost;
     }
 


### PR DESCRIPTION
Right now the only way to change the swamp and plain cost is `ignoreRoads`, but that doesn’t allow explicit control.

Adding this in `_findPath2` will enable it in a variety of areas, including `moveTo`.