### PR TITLE
add StructureLab.prototoype.reverseReaction

### DIFF
--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -465,6 +465,59 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         return C.OK;
     });
 
+    //TODO move to @screeps/common/lib/constants.js
+    C.REVERSE_REACTIONS = {};
+    for(var a in C.REACTIONS){
+        for(var b in C.REACTIONS[a]){
+            C.REVERSE_REACTIONS[C.REACTIONS[a][b]] = [a,b];
+        }
+    }
+
+    StructureLab.prototype.reverseReaction = register.wrapFn(function(lab1, lab2) {
+        if(!this.my) {
+            return C.ERR_NOT_OWNER;
+        }
+        if(this.cooldown > 0) {
+            return C.ERR_TIRED;
+        }
+        if(!utils.checkStructureAgainstController(data(this.id), register.objectsByRoom[data(this.id).room], data(this.room.controller.id))) {
+            return C.ERR_RCL_NOT_ENOUGH;
+        }
+        if(!lab1 || !lab1.id || !register.structures[lab1.id] ||
+        !(lab1 instanceof globals.Structure) || lab1.structureType != C.STRUCTURE_LAB || lab1.id == this.id) {
+            register.assertTargetObject(lab1);
+            return C.ERR_INVALID_TARGET;
+        }
+        if(!lab2 || !lab1.id || !register.structures[lab2.id] ||
+        !(lab2 instanceof globals.Structure) || lab2.structureType != C.STRUCTURE_LAB || lab2.id == this.id) {
+            register.assertTargetObject(lab2);
+            return C.ERR_INVALID_TARGET;
+        }
+        if(this.pos.getRangeTo(lab1) > 2 || this.pos.getRangeTo(lab2) > 2) {
+            return C.ERR_NOT_IN_RANGE;
+        }
+        if(this.mineralAmount < C.LAB_REACTION_AMOUNT) {
+            return C.ERR_NOT_ENOUGH_RESOURCES;
+        }
+        if(lab1.mineralAmount > lab1.mineralCapacity - C.LAB_REACTION_AMOUNT || lab2.mineralAmount > lab2.mineralCapacity - C.LAB_REACTION_AMOUNT) {
+            return C.ERR_FULL;
+        }
+        if(lab1.mineralType === C.REVERSE_REACTIONS[this.mineralType][1]) {
+            [lab1, lab2] = [lab2, lab1]
+        }
+        if(!(
+             (lab1.mineralAmount === 0 || lab1.mineralType === C.REVERSE_REACTIONS[this.mineralType][0])
+             &&
+             (lab2.mineralAmount === 0 || lab2.mineralType === C.REVERSE_REACTIONS[this.mineralType][1])
+            )
+          ) {
+            return C.ERR_INVALID_ARGS;
+        }
+
+        intents.set(this.id, 'reverseReaction', {lab1: lab1.id, lab2: lab2.id});
+        return C.OK;
+    });
+
     StructureLab.prototype.boostCreep = register.wrapFn(function(target, bodyPartsCount) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;

--- a/src/processor.js
+++ b/src/processor.js
@@ -64,7 +64,8 @@ function processRoom(roomId, {intents, objects, users, terrain, gameTime, roomIn
             if (object.type == 'lab') {
                 object._actionLog = object.actionLog;
                 object.actionLog = {
-                    runReaction: null
+                    runReaction: null,
+                    reverseReaction: null
                 };
             }
             if (object.type == 'tower') {

--- a/src/processor/intents/labs/intents.js
+++ b/src/processor/intents/labs/intents.js
@@ -8,6 +8,9 @@ module.exports = function(object, objectIntents, roomObjects, roomTerrain, bulk,
     if(objectIntents.runReaction)
         require('./run-reaction')(object, objectIntents.runReaction, roomObjects, roomTerrain, bulk, bulkUsers, roomController, stats);
 
+    if(objectIntents.reverseReaction)
+        require('./reverse-reaction')(object, objectIntents.reverseReaction, roomObjects, roomTerrain, bulk, bulkUsers, roomController, stats);
+
     if(objectIntents.boostCreep)
         require('./boost-creep')(object, objectIntents.boostCreep, roomObjects, roomTerrain, bulk, bulkUsers, roomController, stats);
 };

--- a/src/processor/intents/labs/reverse-reaction.js
+++ b/src/processor/intents/labs/reverse-reaction.js
@@ -1,0 +1,72 @@
+var _ = require('lodash'),
+    utils =  require('../../../utils'),
+    driver = utils.getDriver(),
+    C = driver.constants;
+
+//TODO move to @screeps/common/lib/constants.js
+C.REVERSE_REACTIONS = {};
+for(var a in C.REACTIONS){
+    for(var b in C.REACTIONS[a]){
+        C.REVERSE_REACTIONS[C.REACTIONS[a][b]] = [a,b];
+    }
+}
+
+module.exports = function(object, intent, roomObjects, roomTerrain, bulk) {
+
+    if(object.cooldown > 0) {
+        return;
+    }
+
+    var lab1 = roomObjects[intent.lab1];
+    if(!lab1 || lab1.type != 'lab' || lab1.mineralAmount > lab1.mineralCapacity - C.LAB_REACTION_AMOUNT) {
+        return;
+    }
+    if(Math.abs(lab1.x - object.x) > 2 || Math.abs(lab1.y - object.y) > 2) {
+        return;
+    }
+
+    var lab2 = roomObjects[intent.lab2];
+    if(!lab2 || lab2.type != 'lab' || lab2.mineralAmount > lab2.mineralCapacity - C.LAB_REACTION_AMOUNT) {
+        return;
+    }
+    if(Math.abs(lab2.x - object.x) > 2 || Math.abs(lab2.y - object.y) > 2) {
+        return;
+    }
+
+    if(object.mineralAmount < C.LAB_REACTION_AMOUNT) {
+        return;
+    }
+
+    if(lab1.mineralType === C.REVERSE_REACTIONS[object.mineralType][1]) {
+        [lab1, lab2] = [lab2, lab1]
+    }
+
+    if(!(
+         (lab1.mineralAmount === 0 || lab1.mineralType === C.REVERSE_REACTIONS[object.mineralType][0])
+         &&
+         (lab2.mineralAmount === 0 || lab2.mineralType === C.REVERSE_REACTIONS[object.mineralType][1])
+        )
+      ) {
+        return;
+    }
+
+    bulk.update(lab1, {mineralAmount: lab1.mineralAmount + C.LAB_REACTION_AMOUNT});
+    if(!lab1.mineralType) {
+        bulk.update(lab1, {mineralType: C.REVERSE_REACTIONS[object.mineralType][0]});
+    }
+    bulk.update(lab2, {mineralAmount: lab2.mineralAmount + C.LAB_REACTION_AMOUNT});
+    if(!lab2.mineralType) {
+        bulk.update(lab2, {mineralType: C.REVERSE_REACTIONS[object.mineralType][1]});
+    }
+
+    bulk.update(object, {
+        mineralAmount: object.mineralAmount - C.LAB_REACTION_AMOUNT,
+        cooldown: C.LAB_COOLDOWN
+    });
+    if(!object.mineralAmount) {
+        bulk.update(object, {mineralType: null});
+    }
+
+    //TODO add client animation for this
+    object.actionLog.reverseReaction = {x1: lab1.x, y1: lab1.y, x2: lab2.x, y2: lab2.y};
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -758,6 +758,12 @@ exports.storeIntents = function(userId, userIntents, userRuntimeData) {
                 lab2: ""+objectIntentsResult.runReaction.lab2
             };
         }
+        if(objectIntentsResult.reverseReaction) {
+            objectIntents.reverseReaction = {
+                lab1: ""+objectIntentsResult.reverseReaction.lab1,
+                lab2: ""+objectIntentsResult.reverseReaction.lab2
+            };
+        }
         if(objectIntentsResult.boostCreep) {
             objectIntents.boostCreep = {
                 id: ""+objectIntentsResult.boostCreep.id,


### PR DESCRIPTION
Intentional use case: when you steal / scavenge / loot boost compounds that you don't want, you can turn them into raw materials to use to make other compounds.

Potential abuse: converting all minerals into arbitrary compounds for denser storage.

Cost tradeoff: consumes as much CPU and lab time and mineral hauling time as normal reactions.

TODO outside this patch:
1. move new constant REVERSE_REACTIONS to screeps/common/lib/constants.js
2. add client support to animate reverse reaction from actionlog