### PR TITLE
Fix simultaneous execution of `attackController`

### DIFF
--- a/src/processor/intents/creeps/intents.js
+++ b/src/processor/intents/creeps/intents.js
@@ -2,6 +2,7 @@ var _ = require('lodash');
 
 var priorities = {
     rangedHeal: ['heal'],
+    attackController: ['rangedHeal', 'heal'],
     dismantle: ['attackController','rangedHeal','heal'],
     repair: ['dismantle','attackController','rangedHeal','heal'],
     build: ['repair','dismantle','attackController','rangedHeal','heal'],


### PR DESCRIPTION
Now matches the [simultaneous action documentation](http://docs.screeps.com/simultaneous-actions.html).
Prior to this change creeps would be able to use `attackController` and `heal`/`rangedHeal` in the same tick.