### PR TITLE
StructureSpawn.destroy behavior fix

### DIFF
--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -1275,8 +1275,14 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
     StructureSpawn.prototype.destroy = register.wrapFn(function() {
 
-        if(!this.my) {
-            return C.ERR_NOT_OWNER;
+        if((!this.my) &&
+           (!this.room.controller || !this.room.controller.my)) {
+                return C.ERR_NOT_OWNER;
+            }
+        }
+
+        if(this.room.find(C.FIND_HOSTILE_CREEPS).length > 0) {
+            return C.ERR_BUSY;
         }
 
         intents.pushByName('room', 'destroyStructure', {roomName: this.room.name, id: this.id});


### PR DESCRIPTION
Currently StructureSpawn (from the API) only checks direct ownership before triggering the destruction via an intent. This means that contrary to the docs, ERR_BUSY can never trigger.

This change applies closer to the standard Structure rules for .destroy:

 * If you are the owner of the room, or the owner of the spawn, and there are no hostile creeps in the room, the .destroy succeeds now.
 * For un-owned StructureSpawns (meaning leftover from another player) if you do not own the room you get ERR_NOT_OWNER.
 * If enemy creeps are in the room regardless of anything else you get ERR_BUSY, as currently documented in the live docs as far back as change history listed.