### PR TITLE
Fix Creep.prototype errors for dead creeps

### DIFF
--- a/src/game/creeps.js
+++ b/src/game/creeps.js
@@ -123,13 +123,15 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
     });
 
     Creep.prototype.toString = register.wrapFn(function() {
-        return `[creep ${!this.id || data(this.id).user == runtimeData.user._id ? this.name : '#'+this.id}]`;
+        return `[creep ${!this.id || this.my ? this.name : '#'+this.id}]`;
     });
 
     Creep.prototype.move = register.wrapFn(function(direction) {
-
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -154,6 +156,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -330,6 +335,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -390,6 +398,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -413,6 +424,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
     Creep.prototype.transfer = register.wrapFn(function(target, resourceType, amount) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -554,6 +568,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -671,6 +688,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -698,6 +718,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -727,6 +750,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -755,6 +781,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -774,6 +803,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -802,6 +834,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -828,6 +863,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -856,6 +894,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -897,6 +938,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -910,6 +954,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -922,6 +969,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -968,6 +1018,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -999,6 +1052,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -1036,6 +1092,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -1069,6 +1128,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -1096,6 +1158,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
         if(!this.my) {
             return C.ERR_NOT_OWNER;
+        }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
         }
         if(this.spawning) {
             return C.ERR_BUSY;
@@ -1125,6 +1190,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         if(!this.my) {
             return C.ERR_NOT_OWNER;
         }
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }
@@ -1145,6 +1213,9 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
 
     Creep.prototype.signController = register.wrapFn(function(target, sign) {
 
+        if(this.hits === 0) {
+            return C.ERR_NO_BODYPART;
+        }
         if(this.spawning) {
             return C.ERR_BUSY;
         }


### PR DESCRIPTION
@o4kapuk and I were talking last night about this error on tombstones, while discussing it, we realized all functions also return the same error. This PR adds a check to each function returning `ERR_NO_BODYPART` if `this.hits === 0`

```Game.getObjectById('5a9f760b8a490d7bc2334b5e')
[Tombstone #5a9f760b8a490d7bc2334b5e]
Game.getObjectById('5a9f760b8a490d7bc2334b5e').creep
[8:30:08 AM][shard0]Error: Could not find an object with ID 5a9f707b75773d7bc1bce702
    at data (/opt/engine/dist/game/creeps.js:48:19)
    at Object. (/opt/engine/dist/game/creeps.js:126:39)
    at Object.toString (evalmachine.:1:72)
    at String ()
    at Object. (/opt/engine/dist/game/console.js:34:41)
    at Object. (evalmachine.:1:72)
    at Object.exports.runCode (/opt/engine/dist/game/game.js:504:58)
    at connectPromise.then.then.data (/opt/engine/dist/core/runtime/runtime.js:370:31)
    at _fulfilled (/opt/engine/dist/core/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/opt/engine/dist/core/node_modules/q/q.js:863:30)```