### PR TITLE
fix: _born-creep unwalkable site

### DIFF
--- a/src/processor/intents/spawns/_born-creep.js
+++ b/src/processor/intents/spawns/_born-creep.js
@@ -7,7 +7,10 @@ var _ = require('lodash'),
 module.exports = function(spawn, creep, roomObjects, roomTerrain, bulk, stats, gameTime) {
 
     var newX, newY, isOccupied, hostileOccupied;
-    var checkObstacleFn = (i) => _.contains(C.OBSTACLE_OBJECT_TYPES, i.type) && i.x == newX && i.y == newY;
+    var checkObstacleFn = (i) => (i.x == newX && i.y == newY) && (
+        _.contains(C.OBSTACLE_OBJECT_TYPES, i.type) ||                                          // just unwalkable
+        (i.type == 'constructionSite' && _.contains(C.OBSTACLE_OBJECT_TYPES, i.structureType))  // unwalkable site
+    );
 
     const directions = spawn.spawning.directions || [1,2,3,4,5,6,7,8];
     const otherDirections = _.difference([1,2,3,4,5,6,7,8], directions);


### PR DESCRIPTION
Fix for the issue "Spawning creeps on top of unwalkable construction sites":
* _Current behavior_: unwalkable construction site doesn't block spawn direction, so creep appears on the top of this site and prevent this site from processing by builder (`ERR_INVALID_TARGET`)
* _Fixed behavior_: unwalkable construction site mark as "obstacles" while spawn direction checking, so they act like ordinary fully built structures (unwalkable stay unwalkable, walkable stay walkable, like containers).

[Example 1](https://files.slack.com/files-pri/T0HJCPP9T-F9NUNU6S3/image.png)
[Example 2](https://screeps.com/a/#!/history/shard0/W13N19?t=24333052)