### PR TITLE
feature: getTerrainOfRoom, fast copy of staticTerrainData[room]

### DIFF
--- a/src/game/game.js
+++ b/src/game/game.js
@@ -376,7 +376,7 @@
 
         _markTime(runtimeData.user._id, 'after objects 2');
 
-        game.map = register.map = map.makeMap(runtimeData, register);
+        game.map = register.map = map.makeMap(runtimeData, register, globals);
 
         markStats('beforeMarket');
 

--- a/src/game/map.js
+++ b/src/game/map.js
@@ -208,9 +208,8 @@ exports.makeMap = function(runtimeData, register) {
             }
             return _.contains(runtimeData.accessibleRooms, roomName);
         },
-		
-		getTerrainAt(x, y, roomName) {
-
+        
+        getTerrainAt(x, y, roomName) {
             if(_.isObject(x)) {
                 y = x.y;
                 roomName = x.roomName;
@@ -228,6 +227,17 @@ exports.makeMap = function(runtimeData, register) {
                 return 'swamp';
             }
             return 'plain';
+        },
+        
+        getTerrainOfRoom(roomName) {
+            if(_.isObject(roomName))
+                roomName = roomName.name;
+            
+            var array = (runtimeData.staticTerrainData || {})[roomName];
+            if(!array)
+                return undefined;
+            
+            return new Uint8Array(array);
         },
 
         getRoomLinearDistance(roomName1, roomName2, continuous) {

--- a/src/game/map.js
+++ b/src/game/map.js
@@ -9,7 +9,7 @@ var utils = require('../utils'),
 
 const kRouteGrid = 30;
 
-exports.makeMap = function(runtimeData, register) {
+exports.makeMap = function(runtimeData, register, globals) {
 
     var heap, openClosed, parents;
     var originX, originY;
@@ -229,17 +229,10 @@ exports.makeMap = function(runtimeData, register) {
             return 'plain';
         },
         
-        getTerrainOfRoom(roomName) {
-            if(_.isObject(roomName))
-                roomName = roomName.name;
-            
-            var array = (runtimeData.staticTerrainData || {})[roomName];
-            if(!array)
-                return undefined;
-            
-            return new Uint8Array(array);
+        getRoomTerrain(roomName) {
+            return new globals.Room.Terrain(roomName);
         },
-
+        
         getRoomLinearDistance(roomName1, roomName2, continuous) {
             return utils.calcRoomsDistance(roomName1, roomName2, continuous);
         },


### PR DESCRIPTION
Suggested `getTerrainOfRoom` is very minor, but useful function: instead of 2500 calls of `getTerrainAt` to acquire static terrain data user now can call `getTerrainOfRoom` once to get **copy** of `runtimeData.staticTerrainData[roomName]` typed array.

There are `TERRAIN_MASK_*` constants within existing API which can be used for future analysis of this `Uint8Array`: **distance transform**, **skeletonization**, **convolution** with CostMatrices, transferring to **WASM** etc. IMHO, terrain data acquiring and transferring is pretty expensive now to try some advanced path/map techniques.

<details><summary>Simple test case to reproduce</summary>

```
const room = Game.rooms[Object.keys(Game.rooms)[0]];
let t = 0;

t = Game.cpu.getUsed();
const arr = Game.map.getTerrainOfRoom(room.name);
t = Game.cpu.getUsed() - t;
console.log(`getTerrainOfRoom   = ${t.toFixed(6)} CPU`);

t = Game.cpu.getUsed();
const own = new Uint8Array(2500);
for(let i = 0; i < 50; ++i)
    for(let j = 0; j < 50; ++j)
        own[i + 50*j] = Game.map.getTerrainAt(i, j, room.name).length;
t = Game.cpu.getUsed() - t;
console.log(`getTerrainAt 2500x = ${t.toFixed(6)} CPU`);
```

</details>

Typical performance tests:
```
[5:42:29 PM]getTerrainAt 2500x = 0.988422 CPU
[5:42:30 PM]getTerrainOfRoom   = 0.015738 CPU
```

_Need reply to ensure there aren't security underwater rocks here (constructor or accessors rewriting?)_

_[Forum thread](https://screeps.com/forum/topic/2138/getterrainofroom-fast-copy-of-staticterraindata-room) to upvote/downvote this feature request :)_
