### PR TITLE
Fix creep death stats

### DIFF
--- a/src/processor/intents/creeps/tick.js
+++ b/src/processor/intents/creeps/tick.js
@@ -89,7 +89,7 @@ module.exports = function(object, roomObjects, roomTerrain, bulk, bulkUsers, roo
             }
 
             if(gameTime >= object.ageTime-1) {
-                require('./_die')(object, roomObjects, bulk, stats, undefined, gameTime);
+                require('./_die')(object, roomObjects, bulk, undefined, undefined, gameTime);
             }
         }
 
@@ -136,7 +136,7 @@ module.exports = function(object, roomObjects, roomTerrain, bulk, bulkUsers, roo
     }
 
     if(object.hits <= 0) {
-        require('./_die')(object, roomObjects, bulk, undefined, undefined, gameTime);
+        require('./_die')(object, roomObjects, bulk, stats, undefined, gameTime);
     }
     else if(object.hits != oldHits) {
 


### PR DESCRIPTION
Currently death count is incremented on
death by old age, it should increment on death by damage instead.
This swaps those behaviors so that it increments properly.