### PR TITLE
Reduce heap pressure of spatials

### DIFF
--- a/src/game/game.js
+++ b/src/game/game.js
@@ -362,7 +362,7 @@
                 register.flags[id] = flag;
                 if(register.byRoom[flagRoomData.room]) {
                     register.byRoom[flagRoomData.room].flags[id] = flag;
-                    let index = info[3] * 50 + info[4];
+                    let index = (+info[3]) * 50 + (+info[4]);
                     let spatial = register.byRoom[flagRoomData.room].spatial.flags;
                     if (spatial[index] === undefined) {
                         spatial[index] = [ flag ];

--- a/src/game/game.js
+++ b/src/game/game.js
@@ -38,10 +38,7 @@
             var keys = Object.keys(reg);
             reg.spatial = {};
             keys.forEach((i) => {
-                reg.spatial[i] = new Array(50);
-                for(var y=0;y<50;y++) {
-                    reg.spatial[i][y] = new Array(50);
-                }
+                reg.spatial[i] = new Array(2500);
             });
         }
     }
@@ -70,8 +67,13 @@
     function addObjectToRegister(register, type, objectInstance, objectRaw) {
         register[type][objectInstance.id] = objectInstance;
         register.byRoom[objectRaw.room][type][objectInstance.id] = objectInstance;
-        register.byRoom[objectRaw.room].spatial[type][objectRaw.y][objectRaw.x] = register.byRoom[objectRaw.room].spatial[type][objectRaw.y][objectRaw.x] || [];
-        register.byRoom[objectRaw.room].spatial[type][objectRaw.y][objectRaw.x].push(objectInstance);
+        let index = objectRaw.x * 50 + objectRaw.y;
+        let spatial = register.byRoom[objectRaw.room].spatial[type];
+        if (spatial[index] === undefined) {
+            spatial[index] = [ objectInstance ];
+        } else {
+            spatial[index].push(objectInstance);
+        }
     }
 
     driver.config.makeGameObject = function makeGameObject (runtimeData, intents, memory, getUsedCpuFn, globals, markStats, sandboxedFunctionWrapper) {
@@ -360,8 +362,13 @@
                 register.flags[id] = flag;
                 if(register.byRoom[flagRoomData.room]) {
                     register.byRoom[flagRoomData.room].flags[id] = flag;
-                    register.byRoom[flagRoomData.room].spatial.flags[info[4]][info[3]] = register.byRoom[flagRoomData.room].spatial.flags[info[4]][info[3]] || [];
-                    register.byRoom[flagRoomData.room].spatial.flags[info[4]][info[3]].push(flag);
+                    let index = info[3] * 50 + info[4];
+                    let spatial = register.byRoom[flagRoomData.room].spatial.flags;
+                    if (spatial[index] === undefined) {
+                        spatial[index] = [ flag ];
+                    } else {
+                        spatial[index].push(flag);
+                    }
                 }
 
                 game.flags[info[0]] = flag;

--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -648,7 +648,7 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
             throw new Error('look coords are out of bounds');
         }
 
-        var typeResult = privateStore[id].lookTypeSpatialRegisters[typeName][y][x];
+        var typeResult = privateStore[id].lookTypeSpatialRegisters[typeName][x * 50 + y];
         if(typeResult) {
             if(outArray) {
                 typeResult.forEach((i) => {


### PR DESCRIPTION
There's some low hanging fruit here. 11 arrays is definitely better than 550.

My local code doesn't use the spatial API at all, but tests on the console look correct. Saves about 200kb on a room with a few objects, so the initial results are very promising. I don't have the infrastructure in place to test it further but I think it'll be a nice perf win.