### PR TITLE
Reduce memory overhead of RoomPosition

### DIFF
--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -1259,7 +1259,7 @@ exports.makePos = function(_register) {
                 if (val < 0 || val > 49 || val !== val) {
                     throw new Error('Invalid coordinate');
                 }
-                this.__packedPos = this.__packedPos & ~0xff | val << 8;
+                this.__packedPos = this.__packedPos & ~0xff | val;
             },
         },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -382,7 +382,12 @@ exports.getRoomNameFromXY = function(x,y) {
 
 exports.roomNameToXY = function(name) {
     let xx = parseInt(name.substr(1), 10);
-    let verticalPos = (xx === 0 ? 1 : Math.ceil(Math.log10(xx + 1))) + 1;
+    let verticalPos = 2;
+    if (xx >= 100) {
+        verticalPos = 4;
+    } else if (xx >= 10) {
+        verticalPos = 3;
+    }
     let yy = parseInt(name.substr(verticalPos + 1), 10);
     let horizontalDir = name.charAt(0);
     let verticalDir = name.charAt(verticalPos);

--- a/src/utils.js
+++ b/src/utils.js
@@ -362,6 +362,8 @@ exports.checkControllerAvailability = function(type, roomObjects, roomController
     return structuresCnt < availableCnt;
 };
 
+// Note that game/rooms.js will swap this function out for a faster version, but may call back to
+// this function.
 exports.getRoomNameFromXY = function(x,y) {
     if(x < 0) {
         x = 'W'+(-x-1);
@@ -379,28 +381,18 @@ exports.getRoomNameFromXY = function(x,y) {
 };
 
 exports.roomNameToXY = function(name) {
-
-    name = name.toUpperCase();
-
-    var match = name.match(/^(\w)(\d+)(\w)(\d+)$/);
-    if(!match) {
-        return [undefined, undefined];
+    let xx = parseInt(name.substr(1), 10);
+    let verticalPos = (xx === 0 ? 1 : Math.ceil(Math.log10(xx + 1))) + 1;
+    let yy = parseInt(name.substr(verticalPos + 1), 10);
+    let horizontalDir = name.charAt(0);
+    let verticalDir = name.charAt(verticalPos);
+    if (horizontalDir === 'W' || horizontalDir === 'w') {
+        xx = -xx - 1;
     }
-    var [,hor,x,ver,y] = match;
-
-    if(hor == 'W') {
-        x = -x-1;
+    if (verticalDir === 'N' || verticalDir === 'n') {
+        yy = -yy - 1;
     }
-    else {
-        x = +x;
-    }
-    if(ver == 'N') {
-        y = -y-1;
-    }
-    else {
-        y = +y;
-    }
-    return [x,y];
+    return [xx, yy];
 };
 
 exports.comparatorDistance = function(target) {


### PR DESCRIPTION
**List of known breaking changes**
- `Object.create(RoomPosition.prototype, ...)` -- please use `new RoomPosition`
- `Object.assign({}, rp)` - properties on RoomPosition are no longer "own properties" so they won't be picked up by functions that filter on own properties
- `rp.x = -1; rp.y = 50` -- invalid values are no longer supported on RoomPosition
- `rp.roomName = 'e1s1'` -- lowercase room names will be converted to uppercase

I'm not sure if this will be a performance win or not. This modifies `RoomPosition` to internally only store a single 32-bit value instead of two numbers and a string. Getters and setters are implemented so that the interface remains the same. The biggest observable difference is that now `x`, `y`, and `roomName` are not "own properties" anymore so something like `Object.assign({}, rp)` won't behave the same. `JSON.stringify(rp)` still works as expected. Invalid values for the 3 properties will now throw if you try to set them. So you can't do `rp.x = -1` or `rp.roomName = 'foo'`. `rp.isEqualTo()` becomes a lot faster.

`utils.getRoomNameFromXY` is modified to always return an existing memoized string instead of constructing the string on the fly. `utils.roomNameToXY` is modified to use simple string ops and math instead of a regex to improve speed, it's 2-3 times faster now. The return value in case of an invalid input is changed from `[undefined,undefined]` to `[NaN,NaN]` but a quick audit of the code suggests this won't be a problem.

My world shows a net heap decrease of just 30kb but I only have 2 creeps and a spawn.

Edit: And obviously now since these are accessors instead of properties that may affect runtime speed. It's unclear if that overhead will be overcome by the reduced memory footprint.