### PR TITLE
Added novice and respawn zone functions to `Game.map`

### DIFF
--- a/src/game/map.js
+++ b/src/game/map.js
@@ -208,8 +208,24 @@ exports.makeMap = function(runtimeData, register) {
             }
             return _.contains(runtimeData.accessibleRooms, roomName);
         },
-		
-		getTerrainAt(x, y, roomName) {
+
+        isRoomNoviceZone(roomName) {
+            return !!runtimeData.zones[roomName] && runtimeData.zones[roomName].novice > Date.now();
+        },
+
+        isRoomRespawnZone(roomName) {
+            return !!runtimeData.zones[roomName] && runtimeData.zones[roomName].respawnArea > Date.now();
+        },
+
+        getRoomNoviceZoneEndDate(roomName) {
+            return runtimeData.zones[roomName] && runtimeData.zones[roomName].novice;
+        },
+
+        getRoomRespawnZoneEndDate(roomName) {
+            return runtimeData.zones[roomName] && runtimeData.zones[roomName].respawnArea;
+        },
+
+        getTerrainAt(x, y, roomName) {
 
             if(_.isObject(x)) {
                 y = x.y;


### PR DESCRIPTION
This is a revision of the attempt in #88 to add respawn and novice zone checks to `Game.map`. This requires a change to driver PRed here:
https://github.com/screeps/driver/pull/28

Example usage:
![image](https://user-images.githubusercontent.com/5143800/38831318-f8d322fe-418c-11e8-8bb6-7d53761d87fb.png)

![image](https://user-images.githubusercontent.com/5143800/38831323-00787a54-418d-11e8-86ee-0ef504617d65.png)
