### PR TITLE
Eliminate many one-element arrays in spatials

### DIFF
--- a/src/game/game.js
+++ b/src/game/game.js
@@ -70,9 +70,11 @@
         let index = objectRaw.x * 50 + objectRaw.y;
         let spatial = register.byRoom[objectRaw.room].spatial[type];
         if (spatial[index] === undefined) {
-            spatial[index] = [ objectInstance ];
-        } else {
+            spatial[index] = objectInstance;
+        } else if (Array.isArray(spatial[index])) {
             spatial[index].push(objectInstance);
+        } else {
+            spatial[index] = [ spatial[index], objectInstance ];
         }
     }
 
@@ -399,7 +401,7 @@
     };
 
     (function() {
-        
+
         var runCodeCache = {};
 
         exports.runCode = function (_globals, _sandboxedFunctionWrapper, _codeModules, _runtimeData, _intents, _memory, _fakeConsole, _consoleCommands, _timeout, _getUsedCpu, _resetUsedCpu, _markStats, _scriptCachedData) {

--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -651,7 +651,7 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         var typeResult = privateStore[id].lookTypeSpatialRegisters[typeName][x * 50 + y];
         if(typeResult) {
             if(outArray) {
-                typeResult.forEach((i) => {
+                var appendToOut = (i) => {
                     item = {type: typeName};
                     item[typeName] = i;
                     if(withCoords) {
@@ -659,10 +659,21 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
                         item.y = y;
                     }
                     outArray.push(item);
-                });
+                };
+                if(Array.isArray(typeResult)) {
+                    typeResult.forEach(appendToOut);
+                }
+                else {
+                    appendToOut(typeResult);
+                }
                 return;
             }
-            return _.clone(typeResult);
+            if(Array.isArray(typeResult)) {
+                return _.clone(typeResult);
+            }
+            else {
+                return [typeResult];
+            }
         }
         return [];
     }


### PR DESCRIPTION
In the vast majority of cases, there is only one object of a given type at a given location in a room. Storing these objects directly in the spatial lookup tables rather than creating a new one-element array for every object eliminates most of these arrays while still support multiple objects of a type by detecting that case and accounting for it.

On my local private server running IVM with a small amount of room objects, this change resulted in a ~15% reduction in heap generated by the for loop over roomObjects in makeGameObject.