### PR TITLE
Support game objects in Memory

### DIFF
--- a/src/game/game.js
+++ b/src/game/game.js
@@ -436,7 +436,12 @@
                 get() {
 
                     try {
-                        runCodeCache[userId].memory._parsed = JSON.parse(runCodeCache[userId].memory.get() || "{}");
+                        runCodeCache[userId].memory._parsed = JSON.parse(runCodeCache[userId].memory.get() || "{}",
+							function(key, val) {
+								return ((_.isObject(val) && val.__objId) ?
+									runCodeCache[userId].globals.Game.getObjectById(val.__objId) : val);
+							}
+						);
                         runCodeCache[userId].memory._parsed.__proto__ = null;
                     }
                     catch(e) {

--- a/src/game/structures.js
+++ b/src/game/structures.js
@@ -1374,6 +1374,21 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
         this.directions = data(spawnId).spawning.directions;
     });
 
+	StructureSpawn.Spawning.prototype.toJSON = function(){
+        var result = {};
+        for(var i in this) {
+            if(i[0] == '_' || _.contains(['toJSON','toString'],i)) {
+                continue;
+            }
+            if(i == 'spawn'){
+				result[i] = {__objId: this.spawn.id, id: this.spawn.id};
+				continue;
+            }
+            result[i] = this[i];
+        }
+        return result;
+	}
+
     StructureSpawn.Spawning.prototype.setDirections = register.wrapFn(function(directions) {
         if(!this.spawn.my) {
             return C.ERR_NOT_OWNER;

--- a/src/utils.js
+++ b/src/utils.js
@@ -931,7 +931,7 @@ exports.defineGameObjectProperties = function(obj, dataFn, properties) {
     Object.defineProperties(obj, propertiesInfo);
 
     obj.toJSON = function() {
-        var result = {};
+        var result = {__objId: this.id};
         for(var i in this) {
             if(i[0] == '_' || _.contains(['toJSON','toString'],i)) {
                 continue;


### PR DESCRIPTION
This adds inter-tick recovery and fresh data for game objects with an `.id` key. This also resolves the circular JSON error when serializing spawns currently spawning (`spawn.spawning.spawn === spawn`). These issues were discussed at https://screeps.com/forum/topic/2208/structurespawn-causing-circular-structure-error-on-json-stringify/