### PR TITLE
Add bounds checking for getTerrainAt

### DIFF
--- a/src/game/map.js
+++ b/src/game/map.js
@@ -216,6 +216,11 @@ exports.makeMap = function(runtimeData, register) {
                 x = x.x;
             }
 
+            // check if coordinates are out of bounds
+            if(x < 0 || x > 49 || y < 0 || y > 49) {
+                return undefined;
+            }
+
             if(!runtimeData.staticTerrainData || !runtimeData.staticTerrainData[roomName]) {
                 return undefined;
             }


### PR DESCRIPTION
Currently, if the user passes an `x,y`-pair into `Game.map.getTerrainAt`, that are out of bounds, the returned value is confusing:

- If `x` is too large, it will wrap around to next `y` values.
- If `x` is negative, it will wrap around to previous `y` values.
- If `y` is too large or negative, it will return `'plain'`.

Having the return value instead be `undefined` in these cases makes it clearer to users debugging malfunctioning code what is going on.  Additionally, it returns `false` when compared with `'plain'`, making searching for free spaces near mining spots a lot easier for new players.
If being able to disable bounds-checking is desired, it would be easy enough to include this functionality as an optional boolean argument for the function.
The docs (specifically https://docs.screeps.com/api/#Game.map.getTerrainAt) will need to be edited to include this change.