### PR TITLE
Lodash v3.10.0 to v3.10.1 (matches rest of project)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@screeps/pathfinding": "^0.4.16",
     "bulk-require": "^0.2.1",
-    "lodash": "^3.10.0",
+    "lodash": "^3.10.1",
     "q": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- screeps/engine is using lodash **^3.10.0**.  
- screeps/driver is using lodash **^3.10.1**.  
- screeps/common is using lodash **^3.10.1**.  
- screeps/backend-local is using lodash **^3.10.1**.  
- screeps/launcher is using lodash **^3.10.1**.  
As is clear from the above, screeps/engine is 1 bugfix release behind the rest of the Screeps project.