### PR TITLE
Added Novice and Respawn Zone detection To Room Object

### DIFF
--- a/src/game/map.js
+++ b/src/game/map.js
@@ -207,6 +207,20 @@ exports.makeMap = function(runtimeData, register, globals) {
             }
             return _.contains(runtimeData.accessibleRooms, roomName);
         },
+	    
+	isRoomNovice(roomName){
+            if(!_.contains(Object.keys(runtimeData.rooms), roomName)){
+                return C.ERR_INVALID_TARGET;
+            }
+            return runtimeData.rooms[roomName].novice > Date.now();
+        },
+
+        isRoomRespawn(roomName){
+            if(!_.contains(Object.keys(runtimeData.rooms), roomName)){
+                return C.ERR_INVALID_TARGET;
+            }
+            return runtimeData.rooms[roomName].respawnArea > Date.now()
+        },
         
         getTerrainAt(x, y, roomName) {
             register.deprecated('Method `Game.map.getTerrainAt` is deprecated and will be removed. Please use a faster method `Game.map.getRoomTerrain` instead.');


### PR DESCRIPTION
In the past, respawn and novice zone detection PRs have added detection to the map, which would have required far more information.

Instead, this PR requires visibility of the room itself, and uses similar methods to the nuker-safety-code. As a result, no additional work is required by the server, as all the information used is being included in the player runtime anyway. 