### PR TITLE
Support for returning false by costCallback option of Room.findPath.

### DIFF
--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -248,6 +248,9 @@ function _findPath2(id, fromPos, toPos, opts) {
                 if(resultMatrix instanceof globals.PathFinder.CostMatrix) {
                     costMatrix = resultMatrix;
                 }
+                else if(resultMatrix === false) {
+                    return false;
+                }
             }
             return costMatrix;
         },


### PR DESCRIPTION
Currently `roomCallback` in `PathFinder.search` has an option to return false instead of cost matrix to efficiently avoid the room entirely. There is no easy way to do that from `Creep.moveTo` efficiently. One could use `PathFinder` directly, but that results in losing much of `Creep.moveTo` utility such as path caching.

`roomCallback` creates the cost matrix and passes it to `costCallback` to modify it. When `costCallback` returns something else, it is ignored. No exception or anything. I propose that at least when `costCallback` returns `false`, it should be treated as if `roomCallback` returned false. This isn't as efficient as coding custom `roomCallback`, since the cost matrix is still created, but at least it is fully compatible with existing code and will not require the player to code all functionality between `Creeps.moveTo` and `Room.findPath` if they just want to avoid certain rooms, e.g., rooms owned enemies.