### PR TITLE
effects gets set to undefined if effects array length is 0

### DIFF
--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -1604,6 +1604,10 @@ exports.makePos = function(_register) {
                 ticksRemaining: i.endTime - runtimeData.time
             })).filter(i => i.ticksRemaining > 0).value();
         }
+
+        if (Array.isArray(this.effects) && this.effects.length === 0) {
+            this.effects = undefined;
+        }
     });
 
     Object.defineProperty(globals, 'RoomObject', {enumerable: true, value: RoomObject});


### PR DESCRIPTION
Right now, there is a discrepency in how the `.effects` property on RoomObjects is handled.

If there are no effects on an object, an object that has never had an effect on it has an undefined `effects` property, whereas objects that have had an effect on them in the past have an `effects` property of `[]`

This change sets `effects` to undefined if there are no effects on the object, making this property consistent for all room objects.