### PR TITLE
Properly reset spawning property of the spawn to null after spawn has been completed.

### DIFF
--- a/src/processor/intents/spawns/_born-creep.js
+++ b/src/processor/intents/spawns/_born-creep.js
@@ -46,6 +46,7 @@ module.exports = function(spawn, creep, scope) {
             y: newY,
             spawning: false
         });
+        bulk.update(spawn, {spawning: null});
         return true;
     }
 
@@ -72,6 +73,7 @@ module.exports = function(spawn, creep, scope) {
             y: hostileOccupied.y,
             spawning: false
         });
+        bulk.update(spawn, {spawning: null});
         return true;
     }
 


### PR DESCRIPTION
This should take care of issue #118 in which is described how the `spawning` property of a `StructureSpawn` is not set to `null` even though the documentation suggests that it should be.