### PR TITLE
fix(processor): use data object in EVENT_OBJECT_DESTROYED

### DIFF
--- a/src/processor/intents/_damage.js
+++ b/src/processor/intents/_damage.js
@@ -48,7 +48,9 @@ module.exports = function(object, target, damage, attackType, scope) {
 
             require('./structures/_destroy')(target, scope, attackType);
 
-            eventLog.push({event: C.EVENT_OBJECT_DESTROYED, objectId: target._id, type: object.type});
+            eventLog.push({event: C.EVENT_OBJECT_DESTROYED, objectId: target._id, data: {
+                type: object.type
+            }});
         }
     }
     else {

--- a/src/processor/intents/creeps/_die.js
+++ b/src/processor/intents/creeps/_die.js
@@ -94,7 +94,7 @@ module.exports = function(object, dropRate, violentDeath, {roomObjects, bulk, st
         bulk.insert(tombstone);
     }
 
-    eventLog.push({event: C.EVENT_OBJECT_DESTROYED, objectId: object._id, type: 'creep'});
+    eventLog.push({event: C.EVENT_OBJECT_DESTROYED, objectId: object._id, data: {type: 'creep'}});
 
     if (violentDeath && stats && object.user != '3' && object.user != '2') {
         stats.inc('creepsLost', object.user, object.body.length);


### PR DESCRIPTION
Every other event uses data subobject
for keeping details about event except EVENT_OBJECT_DESTROYED
This change makes that consistent with other events