### PR TITLE
Fix incorrect return types for Game.market.getHistory()

### DIFF
--- a/src/game/market.js
+++ b/src/game/market.js
@@ -16,9 +16,9 @@ exports.make = function(runtimeData, intents, register) {
         }
         if(!cachedOrders[resourceType]) {
             if(resourceType != 'all' && !_.contains(C.RESOURCES_ALL, resourceType) && !_.contains(C.INTERSHARD_RESOURCES, resourceType)) {
-                return {};
+                return [];
             }
-            cachedOrders[resourceType] = JSON.parse(JSON.stringify(runtimeData.market.orders[resourceType]) || '{}');
+            cachedOrders[resourceType] = JSON.parse(JSON.stringify(runtimeData.market.orders[resourceType]) || '[]');
             for(var i in cachedOrders[resourceType]) {
                 cachedOrders[resourceType][i].price /= 1000;
             }
@@ -45,9 +45,9 @@ exports.make = function(runtimeData, intents, register) {
 
             if(!cachedHistory[resourceType]) {
                 if(resourceType != 'all' && !_.contains(C.RESOURCES_ALL, resourceType) && !_.contains(C.INTERSHARD_RESOURCES, resourceType)) {
-                    return {};
+                    return [];
                 }
-                cachedHistory[resourceType] = JSON.parse(JSON.stringify(runtimeData.market.history[resourceType] || {}));
+                cachedHistory[resourceType] = JSON.parse(JSON.stringify(runtimeData.market.history[resourceType] || []));
             }
             return cachedHistory[resourceType];
         }),


### PR DESCRIPTION
Prevent Game.market.getHistory() returning empty objects if resource is invalid or has no data. Return an empty array instead.

Includes a similar fix for underlying code of Game.market.getAllOrders(), which only works correctly at the moment because of the `_.filter` call.