### PR TITLE
constructionSites scan fewer objects

### DIFF
--- a/src/game/rooms.js
+++ b/src/game/rooms.js
@@ -1068,7 +1068,7 @@ exports.make = function(_runtimeData, _intents, _register, _globals) {
             return C.ERR_INVALID_TARGET;
         }
 
-        if(_(runtimeData.userObjects).filter({type: 'constructionSite'}).size() + createdConstructionSites >= C.MAX_CONSTRUCTION_SITES) {
+        if (_.size(register['constructionSite']) + createdConstructionSites >= C.MAX_CONSTRUCTION_SITES) {
             return C.ERR_FULL;
         }
 


### PR DESCRIPTION
Instead of scanning all objects that the user has visibility on and checking their type, use the register that has been pre-sorted by type already.  This means a maximum of 100 objects are scanned, rather than potentially thousands or tens of thousands.