### PR TITLE
🔨 Allow 100 characters-long powercreep names

### DIFF
--- a/src/processor/global-intents/power/createPowerCreep.js
+++ b/src/processor/global-intents/power/createPowerCreep.js
@@ -18,7 +18,7 @@ module.exports = function(intent, user, {userPowerCreeps, bulkUsersPowerCreeps})
         return;
     }
 
-    var name = intent.name.substring(0,50);
+    var name = intent.name.substring(0,100);
 
     if(_.any(thisUserPowerCreeps, {name})) {
         return;

--- a/src/processor/global-intents/power/renamePowerCreep.js
+++ b/src/processor/global-intents/power/renamePowerCreep.js
@@ -13,7 +13,7 @@ module.exports = function(intent, user, {userPowerCreeps, bulkObjects, bulkUsers
         return;
     }
 
-    var name = intent.name.substring(0,50);
+    var name = intent.name.substring(0,100);
 
     if(_.any(thisUserPowerCreeps, {name})) {
         return;


### PR DESCRIPTION
Both [renaming](https://github.com/screeps/engine/blob/master/src/game/power-creeps.js#L364) and [creating](https://github.com/screeps/engine/blob/master/src/game/power-creeps.js#L396) enforce (and report) a limit of 100. Bring all of the limits in line with one another for consistency.