### PR TITLE
🔨 Fix Array prototype extensions breaking construction site placement at the edges

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -137,8 +137,8 @@ exports.checkConstructionSite = function(objects, structureType, x, y) {
 
     if(_.isString(objects) || objects instanceof Uint8Array) {
         if(borderTiles) {
-            for(var i in borderTiles) {
-                if(!exports.checkTerrain(objects, borderTiles[i][0], borderTiles[i][1], C.TERRAIN_MASK_WALL)) {
+            for(const tile of borderTiles) {
+                if(!exports.checkTerrain(objects, tile[0], tile[1], C.TERRAIN_MASK_WALL)) {
                     return false;
                 }
             }
@@ -154,8 +154,8 @@ exports.checkConstructionSite = function(objects, structureType, x, y) {
 
     if(objects && _.isArray(objects[0]) && _.isString(objects[0][0])) {
         if(borderTiles) {
-            for(var i in borderTiles) {
-                if(!(objects[borderTiles[i][1]][borderTiles[i][0]] & C.TERRAIN_MASK_WALL)) {
+            for(const tile of borderTiles) {
+                if(!(objects[tile[1]][tile[0]] & C.TERRAIN_MASK_WALL)) {
                     return false;
                 }
             }


### PR DESCRIPTION
If you add something like
```js
Array.prototype.last = function() {
  return this[this.length - 1];
}
```
to your bot to get additional methods on array, this piece of code ends up breaking, as the for…in loop will try running over that `last` key and break the check. Fix the issue by using a proper for…of loop.

Ref #126 