### PR TITLE
Reject work intents without energy

### DIFF
--- a/spec/engine/processor/intents/creeps/workWithoutEnergySpec.js
+++ b/spec/engine/processor/intents/creeps/workWithoutEnergySpec.js
@@ -1,0 +1,111 @@
+const utils = require('../../../../../src/utils'),
+    driver = utils.getDriver(),
+    C = driver.constants,
+    build = require('../../../../../src/processor/intents/creeps/build'),
+    repair = require('../../../../../src/processor/intents/creeps/repair'),
+    upgradeController = require('../../../../../src/processor/intents/creeps/upgradeController');
+
+describe('Creep work intents without energy', () => {
+    let creep, bulk, stats, eventLog;
+
+    beforeEach(() => {
+        creep = {
+            _id: 'creep',
+            type: 'creep',
+            user: 'user',
+            room: 'W0N0',
+            x: 10,
+            y: 10,
+            body: [{type: C.WORK, hits: 100}],
+            store: {},
+            actionLog: {}
+        };
+        bulk = jasmine.createSpyObj('bulk', ['update']);
+        stats = jasmine.createSpyObj('stats', ['inc']);
+        eventLog = [];
+    });
+
+    it('ignores build intents', () => {
+        const target = {
+            _id: 'site',
+            type: 'constructionSite',
+            structureType: C.STRUCTURE_ROAD,
+            room: 'W0N0',
+            x: 10,
+            y: 11,
+            progress: 0,
+            progressTotal: 100
+        };
+
+        build(creep, {id: target._id}, {
+            roomObjects: {[target._id]: target},
+            bulk,
+            stats,
+            eventLog
+        });
+
+        expect(target.progress).toBe(0);
+        expect(creep.store.energy).toBeUndefined();
+        expect(bulk.update).not.toHaveBeenCalled();
+        expect(stats.inc).not.toHaveBeenCalled();
+        expect(eventLog).toEqual([]);
+    });
+
+    it('ignores repair intents', () => {
+        const target = {
+            _id: 'road',
+            type: C.STRUCTURE_ROAD,
+            x: 10,
+            y: 11,
+            hits: 1,
+            hitsMax: 100
+        };
+
+        repair(creep, {id: target._id}, {
+            roomObjects: {[target._id]: target},
+            bulk,
+            stats,
+            eventLog
+        });
+
+        expect(target.hits).toBe(1);
+        expect(creep.store.energy).toBeUndefined();
+        expect(bulk.update).not.toHaveBeenCalled();
+        expect(stats.inc).not.toHaveBeenCalled();
+        expect(eventLog).toEqual([]);
+    });
+
+    it('ignores upgradeController intents', () => {
+        const target = {
+            _id: 'controller',
+            type: C.STRUCTURE_CONTROLLER,
+            user: creep.user,
+            room: 'W0N0',
+            x: 10,
+            y: 11,
+            level: 1,
+            progress: 0,
+            downgradeTime: 100000,
+            safeModeAvailable: 0,
+            effects: []
+        };
+        const bulkUsers = jasmine.createSpyObj('bulkUsers', ['inc']);
+
+        upgradeController(creep, {id: target._id}, {
+            roomObjects: {[target._id]: target},
+            bulk,
+            bulkUsers,
+            stats,
+            gameTime: 1,
+            eventLog,
+            users: {}
+        });
+
+        expect(target.progress).toBe(0);
+        expect(creep.store.energy).toBeUndefined();
+        expect(bulk.update).not.toHaveBeenCalled();
+        expect(bulkUsers.inc).not.toHaveBeenCalled();
+        expect(stats.inc).not.toHaveBeenCalled();
+        expect(eventLog).toEqual([]);
+    });
+});

--- a/src/processor/intents/creeps/build.js
+++ b/src/processor/intents/creeps/build.js
@@ -11,7 +11,7 @@ module.exports = function(object, intent, {roomObjects, roomTerrain, bulk, roomC
     if(object.type != 'creep') {
         return;
     }
-    if(object.spawning || !object.store || object.store.energy <= 0) {
+    if(object.spawning || !object.store || !(object.store.energy > 0)) {
         return;
     }
 

--- a/src/processor/intents/creeps/repair.js
+++ b/src/processor/intents/creeps/repair.js
@@ -8,7 +8,7 @@ module.exports = function(object, intent, {roomObjects, bulk, stats, eventLog}) 
     if(object.type != 'creep') {
         return;
     }
-    if(object.spawning || !object.store || object.store.energy <= 0) {
+    if(object.spawning || !object.store || !(object.store.energy > 0)) {
         return;
     }
 

--- a/src/processor/intents/creeps/upgradeController.js
+++ b/src/processor/intents/creeps/upgradeController.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
 
 module.exports = function(object, intent, {roomObjects, bulk, bulkUsers, stats, gameTime, eventLog, users}) {
 
-    if(object.type != 'creep' || object.spawning || !object.store || object.store.energy <= 0) {
+    if(object.type != 'creep' || object.spawning || !object.store || !(object.store.energy > 0)) {
         return;
     }
 


### PR DESCRIPTION
Fixes #151.

## What changed

- Require a strictly positive energy amount before processing build, repair, or controller-upgrade intents.
- Add regression coverage for an empty creep store in all three work-intent handlers.

## Why

`undefined <= 0` is false in JavaScript. When a creep's store lacks an `energy` property, the existing guards therefore let the intent continue and arithmetic propagates `NaN` into creep, target, stats, and event data.

The positive-value check rejects zero, missing, and invalid energy values before any state is changed.

## Validation

- Full Jasmine suite: 111 specs, 0 failures
- Gulp build completed successfully
